### PR TITLE
Fix appearence of disabled dropdowns / disabled input widgets

### DIFF
--- a/themes/catppuccin.yaml
+++ b/themes/catppuccin.yaml
@@ -140,6 +140,12 @@ Catppuccin Latte:
   input-label-ink-color: var(--secondary-text-color)
   input-idle-line-color: var(--primary-text-color)
   input-hover-line-color: var(--accent-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-disabled-line-color: var(--disabled-text-color)
+  input-outlined-idle-border-color: var(--disabled-text-color)
+  input-outlined-hover-border-color: var(--disabled-text-color)
+  input-outlined-disabled-border-color: var(--disabled-text-color)
+  input-disabled-fill-color: rgba(0, 0, 0, 0)
 
   # Toast
   paper-toast-background-color: var(--overlay0)
@@ -296,6 +302,12 @@ Catppuccin Frappe:
   input-label-ink-color: var(--secondary-text-color)
   input-idle-line-color: var(--primary-text-color)
   input-hover-line-color: var(--accent-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-disabled-line-color: var(--disabled-text-color)
+  input-outlined-idle-border-color: var(--disabled-text-color)
+  input-outlined-hover-border-color: var(--disabled-text-color)
+  input-outlined-disabled-border-color: var(--disabled-text-color)
+  input-disabled-fill-color: rgba(0, 0, 0, 0)
 
   # Toast
   paper-toast-background-color: var(--overlay0)
@@ -451,6 +463,12 @@ Catppuccin Macchiato:
   input-label-ink-color: var(--secondary-text-color)
   input-idle-line-color: var(--primary-text-color)
   input-hover-line-color: var(--accent-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-disabled-line-color: var(--disabled-text-color)
+  input-outlined-idle-border-color: var(--disabled-text-color)
+  input-outlined-hover-border-color: var(--disabled-text-color)
+  input-outlined-disabled-border-color: var(--disabled-text-color)
+  input-disabled-fill-color: rgba(0, 0, 0, 0)
 
   # Toast
   paper-toast-background-color: var(--overlay0)
@@ -608,6 +626,12 @@ Catppuccin Mocha:
   input-label-ink-color: var(--secondary-text-color)
   input-idle-line-color: var(--primary-text-color)
   input-hover-line-color: var(--accent-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-disabled-line-color: var(--disabled-text-color)
+  input-outlined-idle-border-color: var(--disabled-text-color)
+  input-outlined-hover-border-color: var(--disabled-text-color)
+  input-outlined-disabled-border-color: var(--disabled-text-color)
+  input-disabled-fill-color: rgba(0, 0, 0, 0)
 
   # Toast
   paper-toast-background-color: var(--overlay0)


### PR DESCRIPTION
Hi All,

When using this awesome theme, I had one issue: there was no CSS for disabled input widgets. This showed up in the WLED integration which uses dropdown boxes for WLED's presets and it looked like this:

![image](https://github.com/catppuccin/home-assistant/assets/33562283/350c38bf-9925-4a87-a1c8-cb913e2a457c)

After applying this proposed change, it looks like this for me:

![image](https://github.com/catppuccin/home-assistant/assets/33562283/9afe7c58-a3a0-40c9-97b1-5b8c18f95733)


The additional code was copied verbatim from a forum post by @tomlut: https://community.home-assistant.io/t/custom-theme-how-to-change-drop-down-menu-background-color/605998/2

I hope this is useful. Thanks!