### PR TITLE
Remove card borders

### DIFF
--- a/themes/catppuccin.yaml
+++ b/themes/catppuccin.yaml
@@ -93,6 +93,7 @@ Catppuccin Latte:
   # Cards
   card-background-color: var(--base)
   ha-card-background: var(--card-background-color)
+  ha-card-border-width: 0px
 
   ha-card-border-radius: "15px"
   ha-card-box-shadow: none
@@ -254,6 +255,7 @@ Catppuccin Frappe:
   # Cards
   card-background-color: var(--surface0)
   ha-card-background: var(--card-background-color)
+  ha-card-border-width: 0px
 
   ha-card-border-radius: "15px"
   ha-card-box-shadow: none
@@ -415,6 +417,7 @@ Catppuccin Macchiato:
   # Cards
   card-background-color: var(--surface0)
   ha-card-background: var(--card-background-color)
+  ha-card-border-width: 0px
 
   ha-card-border-radius: "15px"
   ha-card-box-shadow: none
@@ -578,6 +581,7 @@ Catppuccin Mocha:
   # Cards
   card-background-color: var(--surface0)
   ha-card-background: var(--card-background-color)
+  ha-card-border-width: 0px
 
   ha-card-border-radius: "15px"
   ha-card-box-shadow: none


### PR DESCRIPTION
This PR would remove the borders on nested cards (introduced in HA 2022.11), resolving #2.

Before:
![image](https://github.com/catppuccin/home-assistant/assets/101432365/41fd99e2-30e0-4764-b092-09da0449a8a0)

After:
![image](https://github.com/catppuccin/home-assistant/assets/101432365/d5dd8ed8-acac-4234-9895-a93cb82e5a10)
