### PR TITLE
feat: set themes under light/dark modes

### DIFF
--- a/home-assistant.tera
+++ b/home-assistant.tera
@@ -6,136 +6,138 @@ whiskers:
 
 {%- for _, flavor in flavors -%}
 Catppuccin {{ flavor.identifier | capitalize }}:
-  # Colors
-{%- for _, color in flavor.colors %}
-  {{ color.identifier }}: "#{{ color.hex }}"
-{%- endfor %}
+  modes:
+    {% if flavor.dark %}dark{% else %}light{% endif %}:
+      # Colors
+      {%- for _, color in flavor.colors %}
+      {{ color.identifier }}: "#{{ color.hex }}"
+      {%- endfor %}
 
-  ###########################
+      ###########################
 
-  # Header
-  app-header-background-color: var(--mantle)
-  app-header-text-color: var(--text)
+      # Header
+      app-header-background-color: var(--mantle)
+      app-header-text-color: var(--text)
 
-  # Main Interface colors
-  primary-color: var(--blue)
-  light-primary-color: var(--primary-color)
-  accent-color: var(--yellow)
+      # Main Interface colors
+      primary-color: var(--blue)
+      light-primary-color: var(--primary-color)
+      accent-color: var(--yellow)
 
-  primary-background-color: var(--base)
-  secondary-background-color: var(--base)
+      primary-background-color: var(--base)
+      secondary-background-color: var(--base)
 
-  # Text
-  primary-text-color: var(--text)
-  secondary-text-color: var(--subtext1)
-  text-primary-color: var(--text)
-  divider-color: var(--base)
-  disabled-text-color: var(--overlay0)
-  text-accent-color: var(--base)
+      # Text
+      primary-text-color: var(--text)
+      secondary-text-color: var(--subtext1)
+      text-primary-color: var(--text)
+      divider-color: var(--base)
+      disabled-text-color: var(--overlay0)
+      text-accent-color: var(--base)
 
-  # Sidebar
-  sidebar-background-color: var(--crust)
-  sidebar-selected-background-color: var(--primary-background-color)
+      # Sidebar
+      sidebar-background-color: var(--crust)
+      sidebar-selected-background-color: var(--primary-background-color)
 
-  sidebar-icon-color: var(--subtext0)
-  sidebar-text-color: var(--subtext0)
-  sidebar-selected-icon-color: var(--mauve)
-  sidebar-selected-text-color: var(--mauve)
+      sidebar-icon-color: var(--subtext0)
+      sidebar-text-color: var(--subtext0)
+      sidebar-selected-icon-color: var(--mauve)
+      sidebar-selected-text-color: var(--mauve)
 
-  # Buttons
-  paper-item-icon-color: var(--subtext0)
-  paper-item-icon-active-color: var(--primary-color)
+      # Buttons
+      paper-item-icon-color: var(--subtext0)
+      paper-item-icon-active-color: var(--primary-color)
 
-  # States and Badges
-  state-icon-color: var(--lavender)
-  state-icon-active-color: var(--primary-color)
+      # States and Badges
+      state-icon-color: var(--lavender)
+      state-icon-active-color: var(--primary-color)
 
-  state-icon-unavailable-color: var(--disabled-text-color)
+      state-icon-unavailable-color: var(--disabled-text-color)
 
-  # Sliders
-  paper-slider-knob-color: var(--blue)
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: var(--paper-slider-knob-color)
-  paper-slider-secondary-color: var(--blue)
+      # Sliders
+      paper-slider-knob-color: var(--blue)
+      paper-slider-knob-start-color: var(--paper-slider-knob-color)
+      paper-slider-pin-color: var(--paper-slider-knob-color)
+      paper-slider-active-color: var(--paper-slider-knob-color)
+      paper-slider-secondary-color: var(--blue)
 
-  # Labels
-  label-badge-background-color: var(--surface0)
-  label-badge-text-color: var(--text)
-  label-badge-red: var(--red)
-  label-badge-green: var(--green)
-  label-badge-blue: var(--blue)
-  label-badge-yellow: var(--yellow)
-  label-badge-gray: var(--overlay0)
+      # Labels
+      label-badge-background-color: var(--surface0)
+      label-badge-text-color: var(--text)
+      label-badge-red: var(--red)
+      label-badge-green: var(--green)
+      label-badge-blue: var(--blue)
+      label-badge-yellow: var(--yellow)
+      label-badge-gray: var(--overlay0)
 
-  # Cards
-  card-background-color: var(--surface0)
-  ha-card-background: var(--card-background-color)
-  ha-card-border-width: 0px
+      # Cards
+      card-background-color: var(--surface0)
+      ha-card-background: var(--card-background-color)
+      ha-card-border-width: 0px
 
-  ha-card-border-radius: "15px"
-  ha-card-box-shadow: none
-  paper-dialog-background-color: var(--overlay0)
-  paper-listbox-background-color: var(--overlay0)
-  paper-card-background-color: var(--card-background-color)
+      ha-card-border-radius: "15px"
+      ha-card-box-shadow: none
+      paper-dialog-background-color: var(--overlay0)
+      paper-listbox-background-color: var(--overlay0)
+      paper-card-background-color: var(--card-background-color)
 
-  # Switches
-  switch-checked-button-color: var(--green)
-  switch-checked-track-color: var(--surface2)
-  switch-unchecked-button-color: rgb(--overlay0)
-  switch-unchecked-track-color: rgb(--surface0)
+      # Switches
+      switch-checked-button-color: var(--green)
+      switch-checked-track-color: var(--surface2)
+      switch-unchecked-button-color: rgb(--overlay0)
+      switch-unchecked-track-color: rgb(--surface0)
 
-  # Toggles
-  paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
-  paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
-  paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
+      # Toggles
+      paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
+      paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
+      paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
+      paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
 
-  # Table
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  data-table-background-color: var(--primary-background-color)
-  mdc-checkbox-unchecked-color: var(--overlay0)
+      # Table
+      table-row-background-color: var(--primary-background-color)
+      table-row-alternative-background-color: var(--secondary-background-color)
+      data-table-background-color: var(--primary-background-color)
+      mdc-checkbox-unchecked-color: var(--overlay0)
 
-  # Dropdowns
-  material-background-color: var(--primary-background-color)
-  material-secondary-background-color: var(--primary-background-color)
-  mdc-theme-surface: var(--primary-background-color)
+      # Dropdowns
+      material-background-color: var(--primary-background-color)
+      material-secondary-background-color: var(--primary-background-color)
+      mdc-theme-surface: var(--primary-background-color)
 
-  # Pre/Code
-  markdown-code-background-color: var(--surface0)
+      # Pre/Code
+      markdown-code-background-color: var(--surface0)
 
-  # Checkboxes
-  mdc-select-fill-color: var(--surface0)
-  mdc-select-ink-color: var(--primary-text-color)
-  mdc-select-label-ink-color: var(--subtext1)
-  mdc-select-idle-line-color: var(--primary-text-color)
-  mdc-select-dropdown-icon-color: var(--secondary-text-color)
-  mdc-select-hover-line-color: var(--accent-color)
+      # Checkboxes
+      mdc-select-fill-color: var(--surface0)
+      mdc-select-ink-color: var(--primary-text-color)
+      mdc-select-label-ink-color: var(--subtext1)
+      mdc-select-idle-line-color: var(--primary-text-color)
+      mdc-select-dropdown-icon-color: var(--secondary-text-color)
+      mdc-select-hover-line-color: var(--accent-color)
 
-  # Input
-  input-fill-color: var(--secondary-background-color)
-  input-dropdown-icon-color: var(--secondary-text-color)
-  input-ink-color: var(--primary-text-color)
-  input-label-ink-color: var(--secondary-text-color)
-  input-idle-line-color: var(--primary-text-color)
-  input-hover-line-color: var(--accent-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-disabled-line-color: var(--disabled-text-color)
-  input-outlined-idle-border-color: var(--disabled-text-color)
-  input-outlined-hover-border-color: var(--disabled-text-color)
-  input-outlined-disabled-border-color: var(--disabled-text-color)
-  input-disabled-fill-color: rgba(0, 0, 0, 0)
+      # Input
+      input-fill-color: var(--secondary-background-color)
+      input-dropdown-icon-color: var(--secondary-text-color)
+      input-ink-color: var(--primary-text-color)
+      input-label-ink-color: var(--secondary-text-color)
+      input-idle-line-color: var(--primary-text-color)
+      input-hover-line-color: var(--accent-color)
+      input-disabled-ink-color: var(--disabled-text-color)
+      input-disabled-line-color: var(--disabled-text-color)
+      input-outlined-idle-border-color: var(--disabled-text-color)
+      input-outlined-hover-border-color: var(--disabled-text-color)
+      input-outlined-disabled-border-color: var(--disabled-text-color)
+      input-disabled-fill-color: rgba(0, 0, 0, 0)
 
-  # Toast
-  paper-toast-background-color: var(--overlay0)
+      # Toast
+      paper-toast-background-color: var(--overlay0)
 
-  # Colors
-  error-color: var(--red)
-  warning-color: var(--yellow)
-  success-color: var(--green)
-  info-color: var(--blue)
+      # Colors
+      error-color: var(--red)
+      warning-color: var(--yellow)
+      success-color: var(--green)
+      info-color: var(--blue)
 
-  state-on-color: var(--green)
-  state-off-color: var(--red)
+      state-on-color: var(--green)
+      state-off-color: var(--red)
 {% endfor -%}

--- a/themes/catppuccin.yaml
+++ b/themes/catppuccin.yaml
@@ -1,624 +1,632 @@
 Catppuccin Latte:
-  # Colors
-  rosewater: "#dc8a78"
-  flamingo: "#dd7878"
-  pink: "#ea76cb"
-  mauve: "#8839ef"
-  red: "#d20f39"
-  maroon: "#e64553"
-  peach: "#fe640b"
-  yellow: "#df8e1d"
-  green: "#40a02b"
-  teal: "#179299"
-  sky: "#04a5e5"
-  sapphire: "#209fb5"
-  blue: "#1e66f5"
-  lavender: "#7287fd"
-  text: "#4c4f69"
-  subtext1: "#5c5f77"
-  subtext0: "#6c6f85"
-  overlay2: "#7c7f93"
-  overlay1: "#8c8fa1"
-  overlay0: "#9ca0b0"
-  surface2: "#acb0be"
-  surface1: "#bcc0cc"
-  surface0: "#ccd0da"
-  base: "#eff1f5"
-  mantle: "#e6e9ef"
-  crust: "#dce0e8"
+  modes:
+    light:
+      # Colors
+      rosewater: "#dc8a78"
+      flamingo: "#dd7878"
+      pink: "#ea76cb"
+      mauve: "#8839ef"
+      red: "#d20f39"
+      maroon: "#e64553"
+      peach: "#fe640b"
+      yellow: "#df8e1d"
+      green: "#40a02b"
+      teal: "#179299"
+      sky: "#04a5e5"
+      sapphire: "#209fb5"
+      blue: "#1e66f5"
+      lavender: "#7287fd"
+      text: "#4c4f69"
+      subtext1: "#5c5f77"
+      subtext0: "#6c6f85"
+      overlay2: "#7c7f93"
+      overlay1: "#8c8fa1"
+      overlay0: "#9ca0b0"
+      surface2: "#acb0be"
+      surface1: "#bcc0cc"
+      surface0: "#ccd0da"
+      base: "#eff1f5"
+      mantle: "#e6e9ef"
+      crust: "#dce0e8"
 
-  ###########################
+      ###########################
 
-  # Header
-  app-header-background-color: var(--mantle)
-  app-header-text-color: var(--text)
+      # Header
+      app-header-background-color: var(--mantle)
+      app-header-text-color: var(--text)
 
-  # Main Interface colors
-  primary-color: var(--blue)
-  light-primary-color: var(--primary-color)
-  accent-color: var(--yellow)
+      # Main Interface colors
+      primary-color: var(--blue)
+      light-primary-color: var(--primary-color)
+      accent-color: var(--yellow)
 
-  primary-background-color: var(--base)
-  secondary-background-color: var(--base)
+      primary-background-color: var(--base)
+      secondary-background-color: var(--base)
 
-  # Text
-  primary-text-color: var(--text)
-  secondary-text-color: var(--subtext1)
-  text-primary-color: var(--text)
-  divider-color: var(--base)
-  disabled-text-color: var(--overlay0)
-  text-accent-color: var(--base)
+      # Text
+      primary-text-color: var(--text)
+      secondary-text-color: var(--subtext1)
+      text-primary-color: var(--text)
+      divider-color: var(--base)
+      disabled-text-color: var(--overlay0)
+      text-accent-color: var(--base)
 
-  # Sidebar
-  sidebar-background-color: var(--crust)
-  sidebar-selected-background-color: var(--primary-background-color)
+      # Sidebar
+      sidebar-background-color: var(--crust)
+      sidebar-selected-background-color: var(--primary-background-color)
 
-  sidebar-icon-color: var(--subtext0)
-  sidebar-text-color: var(--subtext0)
-  sidebar-selected-icon-color: var(--mauve)
-  sidebar-selected-text-color: var(--mauve)
+      sidebar-icon-color: var(--subtext0)
+      sidebar-text-color: var(--subtext0)
+      sidebar-selected-icon-color: var(--mauve)
+      sidebar-selected-text-color: var(--mauve)
 
-  # Buttons
-  paper-item-icon-color: var(--subtext0)
-  paper-item-icon-active-color: var(--primary-color)
+      # Buttons
+      paper-item-icon-color: var(--subtext0)
+      paper-item-icon-active-color: var(--primary-color)
 
-  # States and Badges
-  state-icon-color: var(--lavender)
-  state-icon-active-color: var(--primary-color)
+      # States and Badges
+      state-icon-color: var(--lavender)
+      state-icon-active-color: var(--primary-color)
 
-  state-icon-unavailable-color: var(--disabled-text-color)
+      state-icon-unavailable-color: var(--disabled-text-color)
 
-  # Sliders
-  paper-slider-knob-color: var(--blue)
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: var(--paper-slider-knob-color)
-  paper-slider-secondary-color: var(--blue)
+      # Sliders
+      paper-slider-knob-color: var(--blue)
+      paper-slider-knob-start-color: var(--paper-slider-knob-color)
+      paper-slider-pin-color: var(--paper-slider-knob-color)
+      paper-slider-active-color: var(--paper-slider-knob-color)
+      paper-slider-secondary-color: var(--blue)
 
-  # Labels
-  label-badge-background-color: var(--surface0)
-  label-badge-text-color: var(--text)
-  label-badge-red: var(--red)
-  label-badge-green: var(--green)
-  label-badge-blue: var(--blue)
-  label-badge-yellow: var(--yellow)
-  label-badge-gray: var(--overlay0)
+      # Labels
+      label-badge-background-color: var(--surface0)
+      label-badge-text-color: var(--text)
+      label-badge-red: var(--red)
+      label-badge-green: var(--green)
+      label-badge-blue: var(--blue)
+      label-badge-yellow: var(--yellow)
+      label-badge-gray: var(--overlay0)
 
-  # Cards
-  card-background-color: var(--surface0)
-  ha-card-background: var(--card-background-color)
-  ha-card-border-width: 0px
+      # Cards
+      card-background-color: var(--surface0)
+      ha-card-background: var(--card-background-color)
+      ha-card-border-width: 0px
 
-  ha-card-border-radius: "15px"
-  ha-card-box-shadow: none
-  paper-dialog-background-color: var(--overlay0)
-  paper-listbox-background-color: var(--overlay0)
-  paper-card-background-color: var(--card-background-color)
+      ha-card-border-radius: "15px"
+      ha-card-box-shadow: none
+      paper-dialog-background-color: var(--overlay0)
+      paper-listbox-background-color: var(--overlay0)
+      paper-card-background-color: var(--card-background-color)
 
-  # Switches
-  switch-checked-button-color: var(--green)
-  switch-checked-track-color: var(--surface2)
-  switch-unchecked-button-color: rgb(--overlay0)
-  switch-unchecked-track-color: rgb(--surface0)
+      # Switches
+      switch-checked-button-color: var(--green)
+      switch-checked-track-color: var(--surface2)
+      switch-unchecked-button-color: rgb(--overlay0)
+      switch-unchecked-track-color: rgb(--surface0)
 
-  # Toggles
-  paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
-  paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
-  paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
+      # Toggles
+      paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
+      paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
+      paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
+      paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
 
-  # Table
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  data-table-background-color: var(--primary-background-color)
-  mdc-checkbox-unchecked-color: var(--overlay0)
+      # Table
+      table-row-background-color: var(--primary-background-color)
+      table-row-alternative-background-color: var(--secondary-background-color)
+      data-table-background-color: var(--primary-background-color)
+      mdc-checkbox-unchecked-color: var(--overlay0)
 
-  # Dropdowns
-  material-background-color: var(--primary-background-color)
-  material-secondary-background-color: var(--primary-background-color)
-  mdc-theme-surface: var(--primary-background-color)
+      # Dropdowns
+      material-background-color: var(--primary-background-color)
+      material-secondary-background-color: var(--primary-background-color)
+      mdc-theme-surface: var(--primary-background-color)
 
-  # Pre/Code
-  markdown-code-background-color: var(--surface0)
+      # Pre/Code
+      markdown-code-background-color: var(--surface0)
 
-  # Checkboxes
-  mdc-select-fill-color: var(--surface0)
-  mdc-select-ink-color: var(--primary-text-color)
-  mdc-select-label-ink-color: var(--subtext1)
-  mdc-select-idle-line-color: var(--primary-text-color)
-  mdc-select-dropdown-icon-color: var(--secondary-text-color)
-  mdc-select-hover-line-color: var(--accent-color)
+      # Checkboxes
+      mdc-select-fill-color: var(--surface0)
+      mdc-select-ink-color: var(--primary-text-color)
+      mdc-select-label-ink-color: var(--subtext1)
+      mdc-select-idle-line-color: var(--primary-text-color)
+      mdc-select-dropdown-icon-color: var(--secondary-text-color)
+      mdc-select-hover-line-color: var(--accent-color)
 
-  # Input
-  input-fill-color: var(--secondary-background-color)
-  input-dropdown-icon-color: var(--secondary-text-color)
-  input-ink-color: var(--primary-text-color)
-  input-label-ink-color: var(--secondary-text-color)
-  input-idle-line-color: var(--primary-text-color)
-  input-hover-line-color: var(--accent-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-disabled-line-color: var(--disabled-text-color)
-  input-outlined-idle-border-color: var(--disabled-text-color)
-  input-outlined-hover-border-color: var(--disabled-text-color)
-  input-outlined-disabled-border-color: var(--disabled-text-color)
-  input-disabled-fill-color: rgba(0, 0, 0, 0)
+      # Input
+      input-fill-color: var(--secondary-background-color)
+      input-dropdown-icon-color: var(--secondary-text-color)
+      input-ink-color: var(--primary-text-color)
+      input-label-ink-color: var(--secondary-text-color)
+      input-idle-line-color: var(--primary-text-color)
+      input-hover-line-color: var(--accent-color)
+      input-disabled-ink-color: var(--disabled-text-color)
+      input-disabled-line-color: var(--disabled-text-color)
+      input-outlined-idle-border-color: var(--disabled-text-color)
+      input-outlined-hover-border-color: var(--disabled-text-color)
+      input-outlined-disabled-border-color: var(--disabled-text-color)
+      input-disabled-fill-color: rgba(0, 0, 0, 0)
 
-  # Toast
-  paper-toast-background-color: var(--overlay0)
+      # Toast
+      paper-toast-background-color: var(--overlay0)
 
-  # Colors
-  error-color: var(--red)
-  warning-color: var(--yellow)
-  success-color: var(--green)
-  info-color: var(--blue)
+      # Colors
+      error-color: var(--red)
+      warning-color: var(--yellow)
+      success-color: var(--green)
+      info-color: var(--blue)
 
-  state-on-color: var(--green)
-  state-off-color: var(--red)
+      state-on-color: var(--green)
+      state-off-color: var(--red)
 Catppuccin Frappe:
-  # Colors
-  rosewater: "#f2d5cf"
-  flamingo: "#eebebe"
-  pink: "#f4b8e4"
-  mauve: "#ca9ee6"
-  red: "#e78284"
-  maroon: "#ea999c"
-  peach: "#ef9f76"
-  yellow: "#e5c890"
-  green: "#a6d189"
-  teal: "#81c8be"
-  sky: "#99d1db"
-  sapphire: "#85c1dc"
-  blue: "#8caaee"
-  lavender: "#babbf1"
-  text: "#c6d0f5"
-  subtext1: "#b5bfe2"
-  subtext0: "#a5adce"
-  overlay2: "#949cbb"
-  overlay1: "#838ba7"
-  overlay0: "#737994"
-  surface2: "#626880"
-  surface1: "#51576d"
-  surface0: "#414559"
-  base: "#303446"
-  mantle: "#292c3c"
-  crust: "#232634"
+  modes:
+    dark:
+      # Colors
+      rosewater: "#f2d5cf"
+      flamingo: "#eebebe"
+      pink: "#f4b8e4"
+      mauve: "#ca9ee6"
+      red: "#e78284"
+      maroon: "#ea999c"
+      peach: "#ef9f76"
+      yellow: "#e5c890"
+      green: "#a6d189"
+      teal: "#81c8be"
+      sky: "#99d1db"
+      sapphire: "#85c1dc"
+      blue: "#8caaee"
+      lavender: "#babbf1"
+      text: "#c6d0f5"
+      subtext1: "#b5bfe2"
+      subtext0: "#a5adce"
+      overlay2: "#949cbb"
+      overlay1: "#838ba7"
+      overlay0: "#737994"
+      surface2: "#626880"
+      surface1: "#51576d"
+      surface0: "#414559"
+      base: "#303446"
+      mantle: "#292c3c"
+      crust: "#232634"
 
-  ###########################
+      ###########################
 
-  # Header
-  app-header-background-color: var(--mantle)
-  app-header-text-color: var(--text)
+      # Header
+      app-header-background-color: var(--mantle)
+      app-header-text-color: var(--text)
 
-  # Main Interface colors
-  primary-color: var(--blue)
-  light-primary-color: var(--primary-color)
-  accent-color: var(--yellow)
+      # Main Interface colors
+      primary-color: var(--blue)
+      light-primary-color: var(--primary-color)
+      accent-color: var(--yellow)
 
-  primary-background-color: var(--base)
-  secondary-background-color: var(--base)
+      primary-background-color: var(--base)
+      secondary-background-color: var(--base)
 
-  # Text
-  primary-text-color: var(--text)
-  secondary-text-color: var(--subtext1)
-  text-primary-color: var(--text)
-  divider-color: var(--base)
-  disabled-text-color: var(--overlay0)
-  text-accent-color: var(--base)
+      # Text
+      primary-text-color: var(--text)
+      secondary-text-color: var(--subtext1)
+      text-primary-color: var(--text)
+      divider-color: var(--base)
+      disabled-text-color: var(--overlay0)
+      text-accent-color: var(--base)
 
-  # Sidebar
-  sidebar-background-color: var(--crust)
-  sidebar-selected-background-color: var(--primary-background-color)
+      # Sidebar
+      sidebar-background-color: var(--crust)
+      sidebar-selected-background-color: var(--primary-background-color)
 
-  sidebar-icon-color: var(--subtext0)
-  sidebar-text-color: var(--subtext0)
-  sidebar-selected-icon-color: var(--mauve)
-  sidebar-selected-text-color: var(--mauve)
+      sidebar-icon-color: var(--subtext0)
+      sidebar-text-color: var(--subtext0)
+      sidebar-selected-icon-color: var(--mauve)
+      sidebar-selected-text-color: var(--mauve)
 
-  # Buttons
-  paper-item-icon-color: var(--subtext0)
-  paper-item-icon-active-color: var(--primary-color)
+      # Buttons
+      paper-item-icon-color: var(--subtext0)
+      paper-item-icon-active-color: var(--primary-color)
 
-  # States and Badges
-  state-icon-color: var(--lavender)
-  state-icon-active-color: var(--primary-color)
+      # States and Badges
+      state-icon-color: var(--lavender)
+      state-icon-active-color: var(--primary-color)
 
-  state-icon-unavailable-color: var(--disabled-text-color)
+      state-icon-unavailable-color: var(--disabled-text-color)
 
-  # Sliders
-  paper-slider-knob-color: var(--blue)
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: var(--paper-slider-knob-color)
-  paper-slider-secondary-color: var(--blue)
+      # Sliders
+      paper-slider-knob-color: var(--blue)
+      paper-slider-knob-start-color: var(--paper-slider-knob-color)
+      paper-slider-pin-color: var(--paper-slider-knob-color)
+      paper-slider-active-color: var(--paper-slider-knob-color)
+      paper-slider-secondary-color: var(--blue)
 
-  # Labels
-  label-badge-background-color: var(--surface0)
-  label-badge-text-color: var(--text)
-  label-badge-red: var(--red)
-  label-badge-green: var(--green)
-  label-badge-blue: var(--blue)
-  label-badge-yellow: var(--yellow)
-  label-badge-gray: var(--overlay0)
+      # Labels
+      label-badge-background-color: var(--surface0)
+      label-badge-text-color: var(--text)
+      label-badge-red: var(--red)
+      label-badge-green: var(--green)
+      label-badge-blue: var(--blue)
+      label-badge-yellow: var(--yellow)
+      label-badge-gray: var(--overlay0)
 
-  # Cards
-  card-background-color: var(--surface0)
-  ha-card-background: var(--card-background-color)
-  ha-card-border-width: 0px
+      # Cards
+      card-background-color: var(--surface0)
+      ha-card-background: var(--card-background-color)
+      ha-card-border-width: 0px
 
-  ha-card-border-radius: "15px"
-  ha-card-box-shadow: none
-  paper-dialog-background-color: var(--overlay0)
-  paper-listbox-background-color: var(--overlay0)
-  paper-card-background-color: var(--card-background-color)
+      ha-card-border-radius: "15px"
+      ha-card-box-shadow: none
+      paper-dialog-background-color: var(--overlay0)
+      paper-listbox-background-color: var(--overlay0)
+      paper-card-background-color: var(--card-background-color)
 
-  # Switches
-  switch-checked-button-color: var(--green)
-  switch-checked-track-color: var(--surface2)
-  switch-unchecked-button-color: rgb(--overlay0)
-  switch-unchecked-track-color: rgb(--surface0)
+      # Switches
+      switch-checked-button-color: var(--green)
+      switch-checked-track-color: var(--surface2)
+      switch-unchecked-button-color: rgb(--overlay0)
+      switch-unchecked-track-color: rgb(--surface0)
 
-  # Toggles
-  paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
-  paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
-  paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
+      # Toggles
+      paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
+      paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
+      paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
+      paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
 
-  # Table
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  data-table-background-color: var(--primary-background-color)
-  mdc-checkbox-unchecked-color: var(--overlay0)
+      # Table
+      table-row-background-color: var(--primary-background-color)
+      table-row-alternative-background-color: var(--secondary-background-color)
+      data-table-background-color: var(--primary-background-color)
+      mdc-checkbox-unchecked-color: var(--overlay0)
 
-  # Dropdowns
-  material-background-color: var(--primary-background-color)
-  material-secondary-background-color: var(--primary-background-color)
-  mdc-theme-surface: var(--primary-background-color)
+      # Dropdowns
+      material-background-color: var(--primary-background-color)
+      material-secondary-background-color: var(--primary-background-color)
+      mdc-theme-surface: var(--primary-background-color)
 
-  # Pre/Code
-  markdown-code-background-color: var(--surface0)
+      # Pre/Code
+      markdown-code-background-color: var(--surface0)
 
-  # Checkboxes
-  mdc-select-fill-color: var(--surface0)
-  mdc-select-ink-color: var(--primary-text-color)
-  mdc-select-label-ink-color: var(--subtext1)
-  mdc-select-idle-line-color: var(--primary-text-color)
-  mdc-select-dropdown-icon-color: var(--secondary-text-color)
-  mdc-select-hover-line-color: var(--accent-color)
+      # Checkboxes
+      mdc-select-fill-color: var(--surface0)
+      mdc-select-ink-color: var(--primary-text-color)
+      mdc-select-label-ink-color: var(--subtext1)
+      mdc-select-idle-line-color: var(--primary-text-color)
+      mdc-select-dropdown-icon-color: var(--secondary-text-color)
+      mdc-select-hover-line-color: var(--accent-color)
 
-  # Input
-  input-fill-color: var(--secondary-background-color)
-  input-dropdown-icon-color: var(--secondary-text-color)
-  input-ink-color: var(--primary-text-color)
-  input-label-ink-color: var(--secondary-text-color)
-  input-idle-line-color: var(--primary-text-color)
-  input-hover-line-color: var(--accent-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-disabled-line-color: var(--disabled-text-color)
-  input-outlined-idle-border-color: var(--disabled-text-color)
-  input-outlined-hover-border-color: var(--disabled-text-color)
-  input-outlined-disabled-border-color: var(--disabled-text-color)
-  input-disabled-fill-color: rgba(0, 0, 0, 0)
+      # Input
+      input-fill-color: var(--secondary-background-color)
+      input-dropdown-icon-color: var(--secondary-text-color)
+      input-ink-color: var(--primary-text-color)
+      input-label-ink-color: var(--secondary-text-color)
+      input-idle-line-color: var(--primary-text-color)
+      input-hover-line-color: var(--accent-color)
+      input-disabled-ink-color: var(--disabled-text-color)
+      input-disabled-line-color: var(--disabled-text-color)
+      input-outlined-idle-border-color: var(--disabled-text-color)
+      input-outlined-hover-border-color: var(--disabled-text-color)
+      input-outlined-disabled-border-color: var(--disabled-text-color)
+      input-disabled-fill-color: rgba(0, 0, 0, 0)
 
-  # Toast
-  paper-toast-background-color: var(--overlay0)
+      # Toast
+      paper-toast-background-color: var(--overlay0)
 
-  # Colors
-  error-color: var(--red)
-  warning-color: var(--yellow)
-  success-color: var(--green)
-  info-color: var(--blue)
+      # Colors
+      error-color: var(--red)
+      warning-color: var(--yellow)
+      success-color: var(--green)
+      info-color: var(--blue)
 
-  state-on-color: var(--green)
-  state-off-color: var(--red)
+      state-on-color: var(--green)
+      state-off-color: var(--red)
 Catppuccin Macchiato:
-  # Colors
-  rosewater: "#f4dbd6"
-  flamingo: "#f0c6c6"
-  pink: "#f5bde6"
-  mauve: "#c6a0f6"
-  red: "#ed8796"
-  maroon: "#ee99a0"
-  peach: "#f5a97f"
-  yellow: "#eed49f"
-  green: "#a6da95"
-  teal: "#8bd5ca"
-  sky: "#91d7e3"
-  sapphire: "#7dc4e4"
-  blue: "#8aadf4"
-  lavender: "#b7bdf8"
-  text: "#cad3f5"
-  subtext1: "#b8c0e0"
-  subtext0: "#a5adcb"
-  overlay2: "#939ab7"
-  overlay1: "#8087a2"
-  overlay0: "#6e738d"
-  surface2: "#5b6078"
-  surface1: "#494d64"
-  surface0: "#363a4f"
-  base: "#24273a"
-  mantle: "#1e2030"
-  crust: "#181926"
+  modes:
+    dark:
+      # Colors
+      rosewater: "#f4dbd6"
+      flamingo: "#f0c6c6"
+      pink: "#f5bde6"
+      mauve: "#c6a0f6"
+      red: "#ed8796"
+      maroon: "#ee99a0"
+      peach: "#f5a97f"
+      yellow: "#eed49f"
+      green: "#a6da95"
+      teal: "#8bd5ca"
+      sky: "#91d7e3"
+      sapphire: "#7dc4e4"
+      blue: "#8aadf4"
+      lavender: "#b7bdf8"
+      text: "#cad3f5"
+      subtext1: "#b8c0e0"
+      subtext0: "#a5adcb"
+      overlay2: "#939ab7"
+      overlay1: "#8087a2"
+      overlay0: "#6e738d"
+      surface2: "#5b6078"
+      surface1: "#494d64"
+      surface0: "#363a4f"
+      base: "#24273a"
+      mantle: "#1e2030"
+      crust: "#181926"
 
-  ###########################
+      ###########################
 
-  # Header
-  app-header-background-color: var(--mantle)
-  app-header-text-color: var(--text)
+      # Header
+      app-header-background-color: var(--mantle)
+      app-header-text-color: var(--text)
 
-  # Main Interface colors
-  primary-color: var(--blue)
-  light-primary-color: var(--primary-color)
-  accent-color: var(--yellow)
+      # Main Interface colors
+      primary-color: var(--blue)
+      light-primary-color: var(--primary-color)
+      accent-color: var(--yellow)
 
-  primary-background-color: var(--base)
-  secondary-background-color: var(--base)
+      primary-background-color: var(--base)
+      secondary-background-color: var(--base)
 
-  # Text
-  primary-text-color: var(--text)
-  secondary-text-color: var(--subtext1)
-  text-primary-color: var(--text)
-  divider-color: var(--base)
-  disabled-text-color: var(--overlay0)
-  text-accent-color: var(--base)
+      # Text
+      primary-text-color: var(--text)
+      secondary-text-color: var(--subtext1)
+      text-primary-color: var(--text)
+      divider-color: var(--base)
+      disabled-text-color: var(--overlay0)
+      text-accent-color: var(--base)
 
-  # Sidebar
-  sidebar-background-color: var(--crust)
-  sidebar-selected-background-color: var(--primary-background-color)
+      # Sidebar
+      sidebar-background-color: var(--crust)
+      sidebar-selected-background-color: var(--primary-background-color)
 
-  sidebar-icon-color: var(--subtext0)
-  sidebar-text-color: var(--subtext0)
-  sidebar-selected-icon-color: var(--mauve)
-  sidebar-selected-text-color: var(--mauve)
+      sidebar-icon-color: var(--subtext0)
+      sidebar-text-color: var(--subtext0)
+      sidebar-selected-icon-color: var(--mauve)
+      sidebar-selected-text-color: var(--mauve)
 
-  # Buttons
-  paper-item-icon-color: var(--subtext0)
-  paper-item-icon-active-color: var(--primary-color)
+      # Buttons
+      paper-item-icon-color: var(--subtext0)
+      paper-item-icon-active-color: var(--primary-color)
 
-  # States and Badges
-  state-icon-color: var(--lavender)
-  state-icon-active-color: var(--primary-color)
+      # States and Badges
+      state-icon-color: var(--lavender)
+      state-icon-active-color: var(--primary-color)
 
-  state-icon-unavailable-color: var(--disabled-text-color)
+      state-icon-unavailable-color: var(--disabled-text-color)
 
-  # Sliders
-  paper-slider-knob-color: var(--blue)
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: var(--paper-slider-knob-color)
-  paper-slider-secondary-color: var(--blue)
+      # Sliders
+      paper-slider-knob-color: var(--blue)
+      paper-slider-knob-start-color: var(--paper-slider-knob-color)
+      paper-slider-pin-color: var(--paper-slider-knob-color)
+      paper-slider-active-color: var(--paper-slider-knob-color)
+      paper-slider-secondary-color: var(--blue)
 
-  # Labels
-  label-badge-background-color: var(--surface0)
-  label-badge-text-color: var(--text)
-  label-badge-red: var(--red)
-  label-badge-green: var(--green)
-  label-badge-blue: var(--blue)
-  label-badge-yellow: var(--yellow)
-  label-badge-gray: var(--overlay0)
+      # Labels
+      label-badge-background-color: var(--surface0)
+      label-badge-text-color: var(--text)
+      label-badge-red: var(--red)
+      label-badge-green: var(--green)
+      label-badge-blue: var(--blue)
+      label-badge-yellow: var(--yellow)
+      label-badge-gray: var(--overlay0)
 
-  # Cards
-  card-background-color: var(--surface0)
-  ha-card-background: var(--card-background-color)
-  ha-card-border-width: 0px
+      # Cards
+      card-background-color: var(--surface0)
+      ha-card-background: var(--card-background-color)
+      ha-card-border-width: 0px
 
-  ha-card-border-radius: "15px"
-  ha-card-box-shadow: none
-  paper-dialog-background-color: var(--overlay0)
-  paper-listbox-background-color: var(--overlay0)
-  paper-card-background-color: var(--card-background-color)
+      ha-card-border-radius: "15px"
+      ha-card-box-shadow: none
+      paper-dialog-background-color: var(--overlay0)
+      paper-listbox-background-color: var(--overlay0)
+      paper-card-background-color: var(--card-background-color)
 
-  # Switches
-  switch-checked-button-color: var(--green)
-  switch-checked-track-color: var(--surface2)
-  switch-unchecked-button-color: rgb(--overlay0)
-  switch-unchecked-track-color: rgb(--surface0)
+      # Switches
+      switch-checked-button-color: var(--green)
+      switch-checked-track-color: var(--surface2)
+      switch-unchecked-button-color: rgb(--overlay0)
+      switch-unchecked-track-color: rgb(--surface0)
 
-  # Toggles
-  paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
-  paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
-  paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
+      # Toggles
+      paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
+      paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
+      paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
+      paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
 
-  # Table
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  data-table-background-color: var(--primary-background-color)
-  mdc-checkbox-unchecked-color: var(--overlay0)
+      # Table
+      table-row-background-color: var(--primary-background-color)
+      table-row-alternative-background-color: var(--secondary-background-color)
+      data-table-background-color: var(--primary-background-color)
+      mdc-checkbox-unchecked-color: var(--overlay0)
 
-  # Dropdowns
-  material-background-color: var(--primary-background-color)
-  material-secondary-background-color: var(--primary-background-color)
-  mdc-theme-surface: var(--primary-background-color)
+      # Dropdowns
+      material-background-color: var(--primary-background-color)
+      material-secondary-background-color: var(--primary-background-color)
+      mdc-theme-surface: var(--primary-background-color)
 
-  # Pre/Code
-  markdown-code-background-color: var(--surface0)
+      # Pre/Code
+      markdown-code-background-color: var(--surface0)
 
-  # Checkboxes
-  mdc-select-fill-color: var(--surface0)
-  mdc-select-ink-color: var(--primary-text-color)
-  mdc-select-label-ink-color: var(--subtext1)
-  mdc-select-idle-line-color: var(--primary-text-color)
-  mdc-select-dropdown-icon-color: var(--secondary-text-color)
-  mdc-select-hover-line-color: var(--accent-color)
+      # Checkboxes
+      mdc-select-fill-color: var(--surface0)
+      mdc-select-ink-color: var(--primary-text-color)
+      mdc-select-label-ink-color: var(--subtext1)
+      mdc-select-idle-line-color: var(--primary-text-color)
+      mdc-select-dropdown-icon-color: var(--secondary-text-color)
+      mdc-select-hover-line-color: var(--accent-color)
 
-  # Input
-  input-fill-color: var(--secondary-background-color)
-  input-dropdown-icon-color: var(--secondary-text-color)
-  input-ink-color: var(--primary-text-color)
-  input-label-ink-color: var(--secondary-text-color)
-  input-idle-line-color: var(--primary-text-color)
-  input-hover-line-color: var(--accent-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-disabled-line-color: var(--disabled-text-color)
-  input-outlined-idle-border-color: var(--disabled-text-color)
-  input-outlined-hover-border-color: var(--disabled-text-color)
-  input-outlined-disabled-border-color: var(--disabled-text-color)
-  input-disabled-fill-color: rgba(0, 0, 0, 0)
+      # Input
+      input-fill-color: var(--secondary-background-color)
+      input-dropdown-icon-color: var(--secondary-text-color)
+      input-ink-color: var(--primary-text-color)
+      input-label-ink-color: var(--secondary-text-color)
+      input-idle-line-color: var(--primary-text-color)
+      input-hover-line-color: var(--accent-color)
+      input-disabled-ink-color: var(--disabled-text-color)
+      input-disabled-line-color: var(--disabled-text-color)
+      input-outlined-idle-border-color: var(--disabled-text-color)
+      input-outlined-hover-border-color: var(--disabled-text-color)
+      input-outlined-disabled-border-color: var(--disabled-text-color)
+      input-disabled-fill-color: rgba(0, 0, 0, 0)
 
-  # Toast
-  paper-toast-background-color: var(--overlay0)
+      # Toast
+      paper-toast-background-color: var(--overlay0)
 
-  # Colors
-  error-color: var(--red)
-  warning-color: var(--yellow)
-  success-color: var(--green)
-  info-color: var(--blue)
+      # Colors
+      error-color: var(--red)
+      warning-color: var(--yellow)
+      success-color: var(--green)
+      info-color: var(--blue)
 
-  state-on-color: var(--green)
-  state-off-color: var(--red)
+      state-on-color: var(--green)
+      state-off-color: var(--red)
 Catppuccin Mocha:
-  # Colors
-  rosewater: "#f5e0dc"
-  flamingo: "#f2cdcd"
-  pink: "#f5c2e7"
-  mauve: "#cba6f7"
-  red: "#f38ba8"
-  maroon: "#eba0ac"
-  peach: "#fab387"
-  yellow: "#f9e2af"
-  green: "#a6e3a1"
-  teal: "#94e2d5"
-  sky: "#89dceb"
-  sapphire: "#74c7ec"
-  blue: "#89b4fa"
-  lavender: "#b4befe"
-  text: "#cdd6f4"
-  subtext1: "#bac2de"
-  subtext0: "#a6adc8"
-  overlay2: "#9399b2"
-  overlay1: "#7f849c"
-  overlay0: "#6c7086"
-  surface2: "#585b70"
-  surface1: "#45475a"
-  surface0: "#313244"
-  base: "#1e1e2e"
-  mantle: "#181825"
-  crust: "#11111b"
+  modes:
+    dark:
+      # Colors
+      rosewater: "#f5e0dc"
+      flamingo: "#f2cdcd"
+      pink: "#f5c2e7"
+      mauve: "#cba6f7"
+      red: "#f38ba8"
+      maroon: "#eba0ac"
+      peach: "#fab387"
+      yellow: "#f9e2af"
+      green: "#a6e3a1"
+      teal: "#94e2d5"
+      sky: "#89dceb"
+      sapphire: "#74c7ec"
+      blue: "#89b4fa"
+      lavender: "#b4befe"
+      text: "#cdd6f4"
+      subtext1: "#bac2de"
+      subtext0: "#a6adc8"
+      overlay2: "#9399b2"
+      overlay1: "#7f849c"
+      overlay0: "#6c7086"
+      surface2: "#585b70"
+      surface1: "#45475a"
+      surface0: "#313244"
+      base: "#1e1e2e"
+      mantle: "#181825"
+      crust: "#11111b"
 
-  ###########################
+      ###########################
 
-  # Header
-  app-header-background-color: var(--mantle)
-  app-header-text-color: var(--text)
+      # Header
+      app-header-background-color: var(--mantle)
+      app-header-text-color: var(--text)
 
-  # Main Interface colors
-  primary-color: var(--blue)
-  light-primary-color: var(--primary-color)
-  accent-color: var(--yellow)
+      # Main Interface colors
+      primary-color: var(--blue)
+      light-primary-color: var(--primary-color)
+      accent-color: var(--yellow)
 
-  primary-background-color: var(--base)
-  secondary-background-color: var(--base)
+      primary-background-color: var(--base)
+      secondary-background-color: var(--base)
 
-  # Text
-  primary-text-color: var(--text)
-  secondary-text-color: var(--subtext1)
-  text-primary-color: var(--text)
-  divider-color: var(--base)
-  disabled-text-color: var(--overlay0)
-  text-accent-color: var(--base)
+      # Text
+      primary-text-color: var(--text)
+      secondary-text-color: var(--subtext1)
+      text-primary-color: var(--text)
+      divider-color: var(--base)
+      disabled-text-color: var(--overlay0)
+      text-accent-color: var(--base)
 
-  # Sidebar
-  sidebar-background-color: var(--crust)
-  sidebar-selected-background-color: var(--primary-background-color)
+      # Sidebar
+      sidebar-background-color: var(--crust)
+      sidebar-selected-background-color: var(--primary-background-color)
 
-  sidebar-icon-color: var(--subtext0)
-  sidebar-text-color: var(--subtext0)
-  sidebar-selected-icon-color: var(--mauve)
-  sidebar-selected-text-color: var(--mauve)
+      sidebar-icon-color: var(--subtext0)
+      sidebar-text-color: var(--subtext0)
+      sidebar-selected-icon-color: var(--mauve)
+      sidebar-selected-text-color: var(--mauve)
 
-  # Buttons
-  paper-item-icon-color: var(--subtext0)
-  paper-item-icon-active-color: var(--primary-color)
+      # Buttons
+      paper-item-icon-color: var(--subtext0)
+      paper-item-icon-active-color: var(--primary-color)
 
-  # States and Badges
-  state-icon-color: var(--lavender)
-  state-icon-active-color: var(--primary-color)
+      # States and Badges
+      state-icon-color: var(--lavender)
+      state-icon-active-color: var(--primary-color)
 
-  state-icon-unavailable-color: var(--disabled-text-color)
+      state-icon-unavailable-color: var(--disabled-text-color)
 
-  # Sliders
-  paper-slider-knob-color: var(--blue)
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: var(--paper-slider-knob-color)
-  paper-slider-secondary-color: var(--blue)
+      # Sliders
+      paper-slider-knob-color: var(--blue)
+      paper-slider-knob-start-color: var(--paper-slider-knob-color)
+      paper-slider-pin-color: var(--paper-slider-knob-color)
+      paper-slider-active-color: var(--paper-slider-knob-color)
+      paper-slider-secondary-color: var(--blue)
 
-  # Labels
-  label-badge-background-color: var(--surface0)
-  label-badge-text-color: var(--text)
-  label-badge-red: var(--red)
-  label-badge-green: var(--green)
-  label-badge-blue: var(--blue)
-  label-badge-yellow: var(--yellow)
-  label-badge-gray: var(--overlay0)
+      # Labels
+      label-badge-background-color: var(--surface0)
+      label-badge-text-color: var(--text)
+      label-badge-red: var(--red)
+      label-badge-green: var(--green)
+      label-badge-blue: var(--blue)
+      label-badge-yellow: var(--yellow)
+      label-badge-gray: var(--overlay0)
 
-  # Cards
-  card-background-color: var(--surface0)
-  ha-card-background: var(--card-background-color)
-  ha-card-border-width: 0px
+      # Cards
+      card-background-color: var(--surface0)
+      ha-card-background: var(--card-background-color)
+      ha-card-border-width: 0px
 
-  ha-card-border-radius: "15px"
-  ha-card-box-shadow: none
-  paper-dialog-background-color: var(--overlay0)
-  paper-listbox-background-color: var(--overlay0)
-  paper-card-background-color: var(--card-background-color)
+      ha-card-border-radius: "15px"
+      ha-card-box-shadow: none
+      paper-dialog-background-color: var(--overlay0)
+      paper-listbox-background-color: var(--overlay0)
+      paper-card-background-color: var(--card-background-color)
 
-  # Switches
-  switch-checked-button-color: var(--green)
-  switch-checked-track-color: var(--surface2)
-  switch-unchecked-button-color: rgb(--overlay0)
-  switch-unchecked-track-color: rgb(--surface0)
+      # Switches
+      switch-checked-button-color: var(--green)
+      switch-checked-track-color: var(--surface2)
+      switch-unchecked-button-color: rgb(--overlay0)
+      switch-unchecked-track-color: rgb(--surface0)
 
-  # Toggles
-  paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
-  paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
-  paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
+      # Toggles
+      paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
+      paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
+      paper-toggle-button-unchecked-button-color: var(--switch-unchecked-button-color)
+      paper-toggle-button-unchecked-bar-color: var(--switch-unchecked-track-color)
 
-  # Table
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  data-table-background-color: var(--primary-background-color)
-  mdc-checkbox-unchecked-color: var(--overlay0)
+      # Table
+      table-row-background-color: var(--primary-background-color)
+      table-row-alternative-background-color: var(--secondary-background-color)
+      data-table-background-color: var(--primary-background-color)
+      mdc-checkbox-unchecked-color: var(--overlay0)
 
-  # Dropdowns
-  material-background-color: var(--primary-background-color)
-  material-secondary-background-color: var(--primary-background-color)
-  mdc-theme-surface: var(--primary-background-color)
+      # Dropdowns
+      material-background-color: var(--primary-background-color)
+      material-secondary-background-color: var(--primary-background-color)
+      mdc-theme-surface: var(--primary-background-color)
 
-  # Pre/Code
-  markdown-code-background-color: var(--surface0)
+      # Pre/Code
+      markdown-code-background-color: var(--surface0)
 
-  # Checkboxes
-  mdc-select-fill-color: var(--surface0)
-  mdc-select-ink-color: var(--primary-text-color)
-  mdc-select-label-ink-color: var(--subtext1)
-  mdc-select-idle-line-color: var(--primary-text-color)
-  mdc-select-dropdown-icon-color: var(--secondary-text-color)
-  mdc-select-hover-line-color: var(--accent-color)
+      # Checkboxes
+      mdc-select-fill-color: var(--surface0)
+      mdc-select-ink-color: var(--primary-text-color)
+      mdc-select-label-ink-color: var(--subtext1)
+      mdc-select-idle-line-color: var(--primary-text-color)
+      mdc-select-dropdown-icon-color: var(--secondary-text-color)
+      mdc-select-hover-line-color: var(--accent-color)
 
-  # Input
-  input-fill-color: var(--secondary-background-color)
-  input-dropdown-icon-color: var(--secondary-text-color)
-  input-ink-color: var(--primary-text-color)
-  input-label-ink-color: var(--secondary-text-color)
-  input-idle-line-color: var(--primary-text-color)
-  input-hover-line-color: var(--accent-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-disabled-line-color: var(--disabled-text-color)
-  input-outlined-idle-border-color: var(--disabled-text-color)
-  input-outlined-hover-border-color: var(--disabled-text-color)
-  input-outlined-disabled-border-color: var(--disabled-text-color)
-  input-disabled-fill-color: rgba(0, 0, 0, 0)
+      # Input
+      input-fill-color: var(--secondary-background-color)
+      input-dropdown-icon-color: var(--secondary-text-color)
+      input-ink-color: var(--primary-text-color)
+      input-label-ink-color: var(--secondary-text-color)
+      input-idle-line-color: var(--primary-text-color)
+      input-hover-line-color: var(--accent-color)
+      input-disabled-ink-color: var(--disabled-text-color)
+      input-disabled-line-color: var(--disabled-text-color)
+      input-outlined-idle-border-color: var(--disabled-text-color)
+      input-outlined-hover-border-color: var(--disabled-text-color)
+      input-outlined-disabled-border-color: var(--disabled-text-color)
+      input-disabled-fill-color: rgba(0, 0, 0, 0)
 
-  # Toast
-  paper-toast-background-color: var(--overlay0)
+      # Toast
+      paper-toast-background-color: var(--overlay0)
 
-  # Colors
-  error-color: var(--red)
-  warning-color: var(--yellow)
-  success-color: var(--green)
-  info-color: var(--blue)
+      # Colors
+      error-color: var(--red)
+      warning-color: var(--yellow)
+      success-color: var(--green)
+      info-color: var(--blue)
 
-  state-on-color: var(--green)
-  state-off-color: var(--red)
+      state-on-color: var(--green)
+      state-off-color: var(--red)


### PR DESCRIPTION
This supersedes/closes #20, modifying the new Whiskers template to create the same changes. The diff between what output this creates and what #20 did (see below) appears to be the same as the diff of #17 (the Whiskers-ification PR), so I believe this should have the same effect. I don't use Home Assistant, but @hremling can you confirm if this does as your #20 did?

<details>
<summary>Difference in output between this and #20</summary>

```diff
diff --git i/themes/catppuccin.yaml w/themes/catppuccin.yaml
index e9a88eb..7897d14 100644
--- i/themes/catppuccin.yaml
+++ w/themes/catppuccin.yaml
@@ -1,25 +1,7 @@
-####################### LATTE #######################
 Catppuccin Latte:
   modes:
     light:
       # Colors
-      text: "#4c4f69"
-
-      subtext1: "#5c5f77"
-      subtext0: "#6c6f85"
-
-      overlay2: "#7c7f93"
-      overlay1: "#8c8fa1"
-      overlay0: "#9ca0b0"
-
-      surface2: "#acb0be"
-      surface1: "#bcc0cc"
-      surface0: "#ccd0da"
-
-      base: "#eff1f5"
-      mantle: "#e6e9ef"
-      crust: "#dce0e8"
-
       rosewater: "#dc8a78"
       flamingo: "#dd7878"
       pink: "#ea76cb"
@@ -34,6 +16,18 @@ Catppuccin Latte:
       sapphire: "#209fb5"
       blue: "#1e66f5"
       lavender: "#7287fd"
+      text: "#4c4f69"
+      subtext1: "#5c5f77"
+      subtext0: "#6c6f85"
+      overlay2: "#7c7f93"
+      overlay1: "#8c8fa1"
+      overlay0: "#9ca0b0"
+      surface2: "#acb0be"
+      surface1: "#bcc0cc"
+      surface0: "#ccd0da"
+      base: "#eff1f5"
+      mantle: "#e6e9ef"
+      crust: "#dce0e8"
 
       ###########################
 
@@ -44,18 +38,18 @@ Catppuccin Latte:
       # Main Interface colors
       primary-color: var(--blue)
       light-primary-color: var(--primary-color)
-
-      primary-background-color: var(--mantle)
-      secondary-background-color: var(--mantle)
       accent-color: var(--yellow)
 
+      primary-background-color: var(--base)
+      secondary-background-color: var(--base)
+
       # Text
       primary-text-color: var(--text)
       secondary-text-color: var(--subtext1)
       text-primary-color: var(--text)
       divider-color: var(--base)
       disabled-text-color: var(--overlay0)
-      text-accent-color: var(--text)
+      text-accent-color: var(--base)
 
       # Sidebar
       sidebar-background-color: var(--crust)
@@ -93,7 +87,7 @@ Catppuccin Latte:
       label-badge-gray: var(--overlay0)
 
       # Cards
-      card-background-color: var(--base)
+      card-background-color: var(--surface0)
       ha-card-background: var(--card-background-color)
 
       ha-card-border-radius: "15px"
@@ -104,9 +98,10 @@ Catppuccin Latte:
 
       # Switches
       switch-checked-button-color: var(--green)
-      switch-checked-track-color: var(--surface0)
+      switch-checked-track-color: var(--surface2)
       switch-unchecked-button-color: rgb(--overlay0)
       switch-unchecked-track-color: rgb(--surface0)
+
       # Toggles
       paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
       paper-toggle-button-checked-bar-color: var(--switch-checked-track-color)
@@ -160,29 +155,10 @@ Catppuccin Latte:
 
       state-on-color: var(--green)
       state-off-color: var(--red)
-
-####################### FRAPPE ######################
-
 Catppuccin Frappe:
   modes:
     dark:
       # Colors
-      text: "#c6d0f5"
-      subtext1: "#b5bfe2"
-      subtext0: "#a5adce"
-
-      overlay2: "#949cbb"
-      overlay1: "#838ba7"
-      overlay0: "#737994"
-
-      surface2: "#626880"
-      surface1: "#51576d"
-      surface0: "#414559"
-
-      base: "#303446"
-      mantle: "#292c3c"
-      crust: "#232634"
-
       rosewater: "#f2d5cf"
       flamingo: "#eebebe"
       pink: "#f4b8e4"
@@ -197,6 +173,18 @@ Catppuccin Frappe:
       sapphire: "#85c1dc"
       blue: "#8caaee"
       lavender: "#babbf1"
+      text: "#c6d0f5"
+      subtext1: "#b5bfe2"
+      subtext0: "#a5adce"
+      overlay2: "#949cbb"
+      overlay1: "#838ba7"
+      overlay0: "#737994"
+      surface2: "#626880"
+      surface1: "#51576d"
+      surface0: "#414559"
+      base: "#303446"
+      mantle: "#292c3c"
+      crust: "#232634"
 
       ###########################
 
@@ -324,28 +312,10 @@ Catppuccin Frappe:
 
       state-on-color: var(--green)
       state-off-color: var(--red)
-
-####################### MACHIATO ####################
 Catppuccin Macchiato:
   modes:
     dark:
       # Colors
-      text: "#cad3f5"
-      subtext1: "#b8c0e0"
-      subtext0: "#a5adcb"
-
-      overlay2: "#939ab7"
-      overlay1: "#8087a2"
-      overlay0: "#6e738d"
-
-      surface2: "#5b6078"
-      surface1: "#494d64"
-      surface0: "#363a4f"
-
-      base: "#24273a"
-      mantle: "#1e2030"
-      crust: "#181926"
-
       rosewater: "#f4dbd6"
       flamingo: "#f0c6c6"
       pink: "#f5bde6"
@@ -360,6 +330,18 @@ Catppuccin Macchiato:
       sapphire: "#7dc4e4"
       blue: "#8aadf4"
       lavender: "#b7bdf8"
+      text: "#cad3f5"
+      subtext1: "#b8c0e0"
+      subtext0: "#a5adcb"
+      overlay2: "#939ab7"
+      overlay1: "#8087a2"
+      overlay0: "#6e738d"
+      surface2: "#5b6078"
+      surface1: "#494d64"
+      surface0: "#363a4f"
+      base: "#24273a"
+      mantle: "#1e2030"
+      crust: "#181926"
 
       ###########################
 
@@ -487,30 +469,10 @@ Catppuccin Macchiato:
 
       state-on-color: var(--green)
       state-off-color: var(--red)
-
-####################### MOCHA #######################
 Catppuccin Mocha:
   modes:
     dark:
       # Colors
-      text: "#cdd6f4"
-      text-dark: "#000000"
-
-      subtext1: "#bac2de"
-      subtext0: "#a6adc8"
-
-      overlay2: "#9399b2"
-      overlay1: "#7f849c"
-      overlay0: "#6c7086"
-
-      surface2: "#585b70"
-      surface1: "#45475a"
-      surface0: "#313244"
-
-      base: "#1e1e2e"
-      mantle: "#181825"
-      crust: "#11111b"
-
       rosewater: "#f5e0dc"
       flamingo: "#f2cdcd"
       pink: "#f5c2e7"
@@ -525,6 +487,18 @@ Catppuccin Mocha:
       sapphire: "#74c7ec"
       blue: "#89b4fa"
       lavender: "#b4befe"
+      text: "#cdd6f4"
+      subtext1: "#bac2de"
+      subtext0: "#a6adc8"
+      overlay2: "#9399b2"
+      overlay1: "#7f849c"
+      overlay0: "#6c7086"
+      surface2: "#585b70"
+      surface1: "#45475a"
+      surface0: "#313244"
+      base: "#1e1e2e"
+      mantle: "#181825"
+      crust: "#11111b"
 
       ###########################
 
@@ -546,7 +520,7 @@ Catppuccin Mocha:
       text-primary-color: var(--text)
       divider-color: var(--base)
       disabled-text-color: var(--overlay0)
-      text-accent-color: var(--crust)
+      text-accent-color: var(--base)
 
       # Sidebar
       sidebar-background-color: var(--crust)
```

</summary>