### PR TITLE
Fix/unchecked switch track

### DIFF
--- a/home-assistant.tera
+++ b/home-assistant.tera
@@ -85,7 +85,7 @@ Catppuccin {{ flavor.identifier | capitalize }}:
       switch-checked-button-color: var(--green)
       switch-checked-track-color: var(--surface2)
       switch-unchecked-button-color: var(--overlay0)
-      switch-unchecked-track-color: rgb(--surface0)
+      switch-unchecked-track-color: var(--surface2)
 
       # Toggles
       paper-toggle-button-checked-button-color: var(--switch-checked-button-color)

--- a/themes/catppuccin.yaml
+++ b/themes/catppuccin.yaml
@@ -101,7 +101,7 @@ Catppuccin Latte:
       switch-checked-button-color: var(--green)
       switch-checked-track-color: var(--surface2)
       switch-unchecked-button-color: var(--overlay0)
-      switch-unchecked-track-color: rgb(--surface0)
+      switch-unchecked-track-color: var(--surface2)
 
       # Toggles
       paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
@@ -259,7 +259,7 @@ Catppuccin Frappe:
       switch-checked-button-color: var(--green)
       switch-checked-track-color: var(--surface2)
       switch-unchecked-button-color: var(--overlay0)
-      switch-unchecked-track-color: rgb(--surface0)
+      switch-unchecked-track-color: var(--surface2)
 
       # Toggles
       paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
@@ -417,7 +417,7 @@ Catppuccin Macchiato:
       switch-checked-button-color: var(--green)
       switch-checked-track-color: var(--surface2)
       switch-unchecked-button-color: var(--overlay0)
-      switch-unchecked-track-color: rgb(--surface0)
+      switch-unchecked-track-color: var(--surface2)
 
       # Toggles
       paper-toggle-button-checked-button-color: var(--switch-checked-button-color)
@@ -575,7 +575,7 @@ Catppuccin Mocha:
       switch-checked-button-color: var(--green)
       switch-checked-track-color: var(--surface2)
       switch-unchecked-button-color: var(--overlay0)
-      switch-unchecked-track-color: rgb(--surface0)
+      switch-unchecked-track-color: var(--surface2)
 
       # Toggles
       paper-toggle-button-checked-button-color: var(--switch-checked-button-color)


### PR DESCRIPTION
Just changing the variable form rgb to var resulted in the track being the same as the background:
![image](https://github.com/user-attachments/assets/58d733df-9ff2-4c57-a432-9205c89d1057)


with the new configuration:
![image](https://github.com/user-attachments/assets/adb2ce89-d77d-4ae7-8d9c-f00ace4a9293)
