### PR TITLE
chore: add a super basic demo ha instance

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,11 @@
+# Ignore everything in config
+/config/**/*
+
+# Except a few specific config files
+!/config/configuration.yaml
+!/config/.storage/auth_provider.homeassistant
+!/config/.storage/lovelace
+!/config/.storage/onboarding
+
+# Even though they are in a subdirectory
+!*/

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,3 @@
+# Demo
+
+This is a very simple demo Home Assistant setup used for testing and taking consistent screenshots. It doesn't require any special hardware or setup, just a container runner of your choice (Docker or Podman). It launches on port 8123. There is a single user; the username and password are both "demo". The `themes` directory at the root of this repo is automatically injected by Compose.

--- a/demo/compose.yml
+++ b/demo/compose.yml
@@ -1,0 +1,9 @@
+services:
+  home-assistant:
+    image: ghcr.io/home-assistant/home-assistant:2025.9.0
+    restart: unless-stopped
+    volumes:
+      - ./config:/config
+      - ../themes:/config/themes
+    ports:
+      - "8123:8123"

--- a/demo/config/.storage/auth_provider.homeassistant
+++ b/demo/config/.storage/auth_provider.homeassistant
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "auth_provider.homeassistant",
+  "data": {
+    "users": [
+      {
+        "username": "demo",
+        "password": "JDJiJDEyJFRrcmgzd29rUVhIQzRFWm1ELncydmVjZ1FQZDlQcEt5WE1HMFNubWgvbWpXbEJoNGdYUC9t"
+      }
+    ]
+  }
+}

--- a/demo/config/.storage/lovelace
+++ b/demo/config/.storage/lovelace
@@ -1,0 +1,431 @@
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "lovelace",
+  "data": {
+    "config": {
+      "views": [
+        {
+          "title": "Home",
+          "sections": [
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading": "Climate",
+                  "heading_style": "title",
+                  "icon": "mdi:home-thermometer"
+                },
+                {
+                  "graph": "line",
+                  "type": "sensor",
+                  "entity": "sensor.outside_temperature",
+                  "detail": 1,
+                  "name": "Temperature"
+                },
+                {
+                  "graph": "line",
+                  "type": "sensor",
+                  "entity": "sensor.outside_humidity",
+                  "detail": 2,
+                  "name": "Humidity"
+                },
+                {
+                  "features": [
+                    {
+                      "type": "fan-speed"
+                    }
+                  ],
+                  "type": "tile",
+                  "entity": "fan.ceiling_fan",
+                  "features_position": "bottom",
+                  "vertical": false
+                },
+                {
+                  "features": [
+                    {
+                      "type": "fan-speed"
+                    }
+                  ],
+                  "type": "tile",
+                  "entity": "fan.living_room_fan",
+                  "features_position": "bottom",
+                  "vertical": false
+                },
+                {
+                  "type": "thermostat",
+                  "entity": "climate.ecobee",
+                  "grid_options": {
+                    "columns": 12,
+                    "rows": 6
+                  },
+                  "features": [
+                    {
+                      "type": "climate-hvac-modes"
+                    }
+                  ]
+                },
+                {
+                  "type": "humidifier",
+                  "entity": "humidifier.humidifier",
+                  "features": [
+                    {
+                      "type": "humidifier-toggle"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading": "Security",
+                  "heading_style": "title",
+                  "icon": "mdi:alarm-panel"
+                },
+                {
+                  "type": "alarm-panel",
+                  "states": [
+                    "arm_home",
+                    "arm_away"
+                  ],
+                  "entity": "alarm_control_panel.security",
+                  "grid_options": {
+                    "columns": 6,
+                    "rows": 8
+                  }
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.movement_backyard",
+                  "features_position": "bottom",
+                  "vertical": false
+                },
+                {
+                  "type": "tile",
+                  "entity": "lock.front_door",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "icon_tap_action": {
+                    "action": "toggle"
+                  }
+                },
+                {
+                  "type": "tile",
+                  "entity": "lock.kitchen_door",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "icon_tap_action": {
+                    "action": "toggle"
+                  }
+                },
+                {
+                  "features": [
+                    {
+                      "type": "lock-open-door"
+                    }
+                  ],
+                  "type": "tile",
+                  "entity": "lock.openable_lock",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "icon_tap_action": {
+                    "action": "toggle"
+                  }
+                },
+                {
+                  "type": "tile",
+                  "entity": "lock.poorly_installed_door",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "icon_tap_action": {
+                    "action": "toggle"
+                  }
+                },
+                {
+                  "type": "tile",
+                  "entity": "siren.siren_with_all_features",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "icon_tap_action": {
+                    "action": "toggle"
+                  }
+                },
+                {
+                  "type": "tile",
+                  "entity": "cover.garage_door",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "icon_tap_action": {
+                    "action": "toggle"
+                  }
+                },
+                {
+                  "type": "heading",
+                  "icon": "mdi:music",
+                  "heading": "Media",
+                  "heading_style": "title"
+                },
+                {
+                  "type": "media-control",
+                  "entity": "media_player.browse"
+                },
+                {
+                  "type": "media-control",
+                  "entity": "media_player.bedroom"
+                },
+                {
+                  "type": "media-control",
+                  "entity": "media_player.living_room"
+                }
+              ]
+            },
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading": "Lighting",
+                  "heading_style": "title",
+                  "icon": "mdi:floor-lamp"
+                },
+                {
+                  "type": "tile",
+                  "entity": "light.bed_light",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "features": [
+                    {
+                      "type": "light-brightness"
+                    },
+                    {
+                      "type": "light-color-temp"
+                    }
+                  ]
+                },
+                {
+                  "type": "tile",
+                  "entity": "light.ceiling_lights",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "features": [
+                    {
+                      "type": "light-brightness"
+                    },
+                    {
+                      "type": "light-color-temp"
+                    }
+                  ]
+                },
+                {
+                  "type": "tile",
+                  "entity": "light.living_room_rgbww_lights",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "features": [
+                    {
+                      "type": "light-brightness"
+                    }
+                  ]
+                },
+                {
+                  "type": "tile",
+                  "entity": "light.office_rgbw_lights",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "features": [
+                    {
+                      "type": "light-brightness"
+                    }
+                  ]
+                },
+                {
+                  "type": "tile",
+                  "entity": "light.entrance_color_white_lights",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "features": [
+                    {
+                      "type": "light-brightness"
+                    }
+                  ]
+                },
+                {
+                  "type": "tile",
+                  "entity": "light.kitchen_lights",
+                  "features_position": "bottom",
+                  "vertical": false,
+                  "features": [
+                    {
+                      "type": "light-brightness"
+                    },
+                    {
+                      "type": "light-color-temp"
+                    }
+                  ]
+                },
+                {
+                  "type": "tile",
+                  "entity": "switch.decorative_lights",
+                  "features_position": "bottom",
+                  "vertical": false
+                },
+                {
+                  "type": "heading",
+                  "icon": "mdi:weather-partly-cloudy",
+                  "heading": "Outdoors",
+                  "heading_style": "title"
+                },
+                {
+                  "show_current": true,
+                  "show_forecast": true,
+                  "type": "weather-forecast",
+                  "entity": "weather.demo_weather_south",
+                  "forecast_type": "daily"
+                },
+                {
+                  "type": "heading",
+                  "icon": "mdi:pipe-valve",
+                  "heading": "Valves",
+                  "heading_style": "subtitle",
+                  "grid_options": {
+                    "columns": 6,
+                    "rows": "auto"
+                  }
+                },
+                {
+                  "type": "heading",
+                  "icon": "",
+                  "heading": "Patio",
+                  "heading_style": "subtitle",
+                  "grid_options": {
+                    "columns": 6,
+                    "rows": "auto"
+                  }
+                },
+                {
+                  "type": "tile",
+                  "entity": "valve.front_garden",
+                  "features_position": "bottom",
+                  "vertical": false
+                },
+                {
+                  "features": [
+                    {
+                      "type": "cover-tilt-position"
+                    },
+                    {
+                      "type": "cover-tilt"
+                    }
+                  ],
+                  "type": "tile",
+                  "entity": "cover.pergola_roof",
+                  "features_position": "bottom",
+                  "vertical": false
+                },
+                {
+                  "type": "tile",
+                  "entity": "valve.orchard",
+                  "features_position": "bottom",
+                  "vertical": false
+                }
+              ]
+            },
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading": "Inputs",
+                  "heading_style": "title",
+                  "icon": "mdi:form-textbox"
+                },
+                {
+                  "type": "entities",
+                  "entities": [
+                    {
+                      "entity": "button.push"
+                    },
+                    {
+                      "entity": "number.large_range"
+                    },
+                    {
+                      "entity": "number.small_range"
+                    },
+                    {
+                      "entity": "number.temperature_setting"
+                    },
+                    {
+                      "entity": "number.volume"
+                    },
+                    {
+                      "entity": "select.speed"
+                    },
+                    {
+                      "entity": "text.text"
+                    },
+                    {
+                      "entity": "date.date"
+                    },
+                    {
+                      "entity": "datetime.date_and_time"
+                    }
+                  ]
+                },
+                {
+                  "type": "heading",
+                  "icon": "mdi:chart-areaspline",
+                  "heading": "Stats",
+                  "heading_style": "title"
+                },
+                {
+                  "chart_type": "line",
+                  "period": "hour",
+                  "type": "statistics-graph",
+                  "entities": [
+                    "sensor.total_energy_kwh",
+                    "sensor.total_energy_mwh"
+                  ],
+                  "days_to_show": 3,
+                  "hide_legend": true,
+                  "logarithmic_scale": false
+                }
+              ]
+            }
+          ],
+          "badges": [
+            {
+              "type": "entity",
+              "show_name": true,
+              "show_state": true,
+              "show_icon": true,
+              "entity": "air_quality.demo_air_quality_home",
+              "name": "Air Quiality"
+            },
+            {
+              "type": "entity",
+              "show_name": false,
+              "show_state": true,
+              "show_icon": true,
+              "entity": "device_tracker.demo_home_boy"
+            },
+            {
+              "type": "entity",
+              "show_name": true,
+              "show_state": true,
+              "show_icon": true,
+              "entity": "binary_sensor.basement_floor_wet",
+              "name": "Basement Floor"
+            }
+          ],
+          "type": "sections",
+          "max_columns": 4,
+          "cards": []
+        }
+      ]
+    }
+  }
+}

--- a/demo/config/.storage/onboarding
+++ b/demo/config/.storage/onboarding
@@ -1,0 +1,13 @@
+{
+  "version": 4,
+  "minor_version": 1,
+  "key": "onboarding",
+  "data": {
+    "done": [
+      "user",
+      "core_config",
+      "analytics",
+      "integration"
+    ]
+  }
+}

--- a/demo/config/configuration.yaml
+++ b/demo/config/configuration.yaml
@@ -1,0 +1,8 @@
+# Loads default set of integrations. Do not remove.
+default_config:
+
+# Load frontend themes from the themes folder
+frontend:
+  themes: !include_dir_merge_named themes
+
+demo: []


### PR DESCRIPTION
This is not yet ready for prime-time. All the demo sensors output a single constant value, which makes for some really boring graphs. I still want to clean that up by generating some fake historical data when the instance is launched, probably via a custom Home Assistant integration, but I haven't had the time to finish that up yet.

Ideally once this is done it could be made part of the CI process: any new PR could have screenshots generated, and any differences highlighted in a comment. But that's a stretch goal, especially since the settings page has a random tip at the bottom that we'd have to deal with somehow.