### PR TITLE
fix: explicitly set primary color

### DIFF
--- a/home-assistant.tera
+++ b/home-assistant.tera
@@ -259,7 +259,7 @@ text-light-primary-color: var(--catppuccin-crust)
 disabled-text-color: var(--catppuccin-overlay1)
 
 # Main interface colors
-# primary-color: var(--ha-color-primary-40)
+primary-color: var(--ha-color-primary-40)
 dark-primary-color: var(--ha-color-primary-30)
 darker-primary-color: var(--ha-color-primary-20)
 light-primary-color: var(--ha-color-primary-50)

--- a/themes/catppuccin.yaml
+++ b/themes/catppuccin.yaml
@@ -293,7 +293,7 @@ Catppuccin Latte:
   disabled-text-color: var(--catppuccin-overlay1)
 
   # Main interface colors
-  # primary-color: var(--ha-color-primary-40)
+  primary-color: var(--ha-color-primary-40)
   dark-primary-color: var(--ha-color-primary-30)
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
@@ -744,7 +744,7 @@ Catppuccin Frappe:
   disabled-text-color: var(--catppuccin-overlay1)
 
   # Main interface colors
-  # primary-color: var(--ha-color-primary-40)
+  primary-color: var(--ha-color-primary-40)
   dark-primary-color: var(--ha-color-primary-30)
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
@@ -1195,7 +1195,7 @@ Catppuccin Macchiato:
   disabled-text-color: var(--catppuccin-overlay1)
 
   # Main interface colors
-  # primary-color: var(--ha-color-primary-40)
+  primary-color: var(--ha-color-primary-40)
   dark-primary-color: var(--ha-color-primary-30)
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
@@ -1646,7 +1646,7 @@ Catppuccin Mocha:
   disabled-text-color: var(--catppuccin-overlay1)
 
   # Main interface colors
-  # primary-color: var(--ha-color-primary-40)
+  primary-color: var(--ha-color-primary-40)
   dark-primary-color: var(--ha-color-primary-30)
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
@@ -2099,7 +2099,7 @@ Catppuccin Auto Latte Frappe:
       disabled-text-color: var(--catppuccin-overlay1)
 
       # Main interface colors
-      # primary-color: var(--ha-color-primary-40)
+      primary-color: var(--ha-color-primary-40)
       dark-primary-color: var(--ha-color-primary-30)
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
@@ -2546,7 +2546,7 @@ Catppuccin Auto Latte Frappe:
       disabled-text-color: var(--catppuccin-overlay1)
 
       # Main interface colors
-      # primary-color: var(--ha-color-primary-40)
+      primary-color: var(--ha-color-primary-40)
       dark-primary-color: var(--ha-color-primary-30)
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
@@ -2995,7 +2995,7 @@ Catppuccin Auto Latte Macchiato:
       disabled-text-color: var(--catppuccin-overlay1)
 
       # Main interface colors
-      # primary-color: var(--ha-color-primary-40)
+      primary-color: var(--ha-color-primary-40)
       dark-primary-color: var(--ha-color-primary-30)
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
@@ -3442,7 +3442,7 @@ Catppuccin Auto Latte Macchiato:
       disabled-text-color: var(--catppuccin-overlay1)
 
       # Main interface colors
-      # primary-color: var(--ha-color-primary-40)
+      primary-color: var(--ha-color-primary-40)
       dark-primary-color: var(--ha-color-primary-30)
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
@@ -3891,7 +3891,7 @@ Catppuccin Auto Latte Mocha:
       disabled-text-color: var(--catppuccin-overlay1)
 
       # Main interface colors
-      # primary-color: var(--ha-color-primary-40)
+      primary-color: var(--ha-color-primary-40)
       dark-primary-color: var(--ha-color-primary-30)
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
@@ -4338,7 +4338,7 @@ Catppuccin Auto Latte Mocha:
       disabled-text-color: var(--catppuccin-overlay1)
 
       # Main interface colors
-      # primary-color: var(--ha-color-primary-40)
+      primary-color: var(--ha-color-primary-40)
       dark-primary-color: var(--ha-color-primary-30)
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)


### PR DESCRIPTION
This is a no-op for most Home Assistant pages, but it does fix color theming in HACS. This is due to the HACS page loading an old version of the default theme variables that used an explicit hex code instead of the modern `var()`. It's also probably just a good idea to actually set both of the explicitly supported theme variables, not just one of them.

Currently, with v2.1.1, the HACS page looks like this:

<img width="1718" height="947" alt="Screenshot 2025-11-24 at 2 23 47 AM" src="https://github.com/user-attachments/assets/a50bd56c-c4c8-4a97-8229-1dd25ac8556f" />

With this PR applied it becomes:

<img width="1721" height="944" alt="Screenshot 2025-11-24 at 2 24 28 AM" src="https://github.com/user-attachments/assets/0f99652f-3601-4c2c-a208-5b33b7b8cdcd" />
