### PR TITLE
chore: ask for browser details in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -55,6 +55,12 @@ body:
       placeholder: "20250828.0"
     validations:
       required: true
+  - type: input
+    attributes:
+      label: What browser are you using?
+      placeholder: Firefox 148.0
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Any additional comments?


### PR DESCRIPTION
When dealing with display issues it is useful to know what browser(s) the issue is occurring on. Previously we were not asking for that information, this fixes that.