### PR TITLE
fix: account for new semantic colors

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -4,7 +4,7 @@
 # Except a few specific config files
 !/config/configuration.yaml
 !/config/.storage/auth_provider.homeassistant
-!/config/.storage/lovelace
+!/config/.storage/lovelace*
 !/config/.storage/onboarding
 
 # Even though they are in a subdirectory

--- a/demo/compose.yml
+++ b/demo/compose.yml
@@ -1,6 +1,6 @@
 services:
   home-assistant:
-    image: ghcr.io/home-assistant/home-assistant:2026.1.1
+    image: ghcr.io/home-assistant/home-assistant:2026.4.0
     restart: unless-stopped
     volumes:
       - ./config:/config

--- a/demo/compose.yml
+++ b/demo/compose.yml
@@ -1,6 +1,6 @@
 services:
   home-assistant:
-    image: ghcr.io/home-assistant/home-assistant:2026.4.0
+    image: ghcr.io/home-assistant/home-assistant:2026.4.1
     restart: unless-stopped
     volumes:
       - ./config:/config

--- a/demo/config/.storage/lovelace.lovelace
+++ b/demo/config/.storage/lovelace.lovelace
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "minor_version": 1,
-  "key": "lovelace",
+  "key": "lovelace.lovelace",
   "data": {
     "config": {
       "views": [

--- a/demo/config/.storage/lovelace_dashboards
+++ b/demo/config/.storage/lovelace_dashboards
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "lovelace_dashboards",
+  "data": {
+    "items": [
+      {
+        "id": "lovelace",
+        "icon": "mdi:view-dashboard",
+        "title": "Overview",
+        "url_path": "lovelace",
+        "mode": "storage",
+        "show_in_sidebar": true,
+        "require_admin": false
+      }
+    ]
+  }
+}

--- a/home-assistant.tera
+++ b/home-assistant.tera
@@ -97,7 +97,11 @@ ha-color-green-95: {{ flavor.colors.green | mix(color=flavor.colors.base, amount
 ######################
 # HA Semantic Colors #
 ######################
-# List from the "semantic.globals.ts" file in home-assistant/frontend.
+# This section resets HA's semantic colors to their "light mode" settings. We do
+# this because due to the way this theme works it is much easier to swap out the
+# underlying palette than the semantic uses of it.
+#
+# Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
 ha-color-focus: var(--ha-color-orange-60)
 
@@ -108,27 +112,27 @@ ha-color-text-disabled: var(--catppuccin-overlay1)
 ha-color-text-link: var(--catppuccin-blue)
 
 # Border primary
-ha-color-border-primary-quiet: var(--ha-color-primary-80)
+ha-color-border-primary-quiet: var(--ha-color-primary-90)
 ha-color-border-primary-normal: var(--ha-color-primary-70)
 ha-color-border-primary-loud: var(--ha-color-primary-40)
 
 # Border neutral
-ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
 ha-color-border-neutral-normal: var(--ha-color-neutral-60)
 ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
 # Border danger
-ha-color-border-danger-quiet: var(--ha-color-red-80)
+ha-color-border-danger-quiet: var(--ha-color-red-90)
 ha-color-border-danger-normal: var(--ha-color-red-70)
 ha-color-border-danger-loud: var(--ha-color-red-40)
 
 # Border warning
-ha-color-border-warning-quiet: var(--ha-color-orange-80)
+ha-color-border-warning-quiet: var(--ha-color-orange-90)
 ha-color-border-warning-normal: var(--ha-color-orange-70)
 ha-color-border-warning-loud: var(--ha-color-orange-40)
 
 # Border success
-ha-color-border-success-quiet: var(--ha-color-green-80)
+ha-color-border-success-quiet: var(--ha-color-green-90)
 ha-color-border-success-normal: var(--ha-color-green-70)
 ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -245,6 +249,18 @@ ha-color-on-warning-loud: var(--white-color)
 ha-color-on-success-quiet: var(--ha-color-green-50)
 ha-color-on-success-normal: var(--ha-color-green-40)
 ha-color-on-success-loud: var(--white-color)
+
+# Surfaces
+ha-color-surface-default: var(--ha-color-neutral-95)
+ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+# Forms
+ha-color-form-background: var(--ha-color-neutral-95)
+ha-color-form-background-hover: var(--ha-color-neutral-90)
+ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+# Scrollable fade
+ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
 ###################
 # HA Other Colors #

--- a/themes/catppuccin.yaml
+++ b/themes/catppuccin.yaml
@@ -131,7 +131,11 @@ Catppuccin Latte:
   ######################
   # HA Semantic Colors #
   ######################
-  # List from the "semantic.globals.ts" file in home-assistant/frontend.
+  # This section resets HA's semantic colors to their "light mode" settings. We do
+  # this because due to the way this theme works it is much easier to swap out the
+  # underlying palette than the semantic uses of it.
+  #
+  # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
   ha-color-focus: var(--ha-color-orange-60)
 
@@ -142,27 +146,27 @@ Catppuccin Latte:
   ha-color-text-link: var(--catppuccin-blue)
 
   # Border primary
-  ha-color-border-primary-quiet: var(--ha-color-primary-80)
+  ha-color-border-primary-quiet: var(--ha-color-primary-90)
   ha-color-border-primary-normal: var(--ha-color-primary-70)
   ha-color-border-primary-loud: var(--ha-color-primary-40)
 
   # Border neutral
-  ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+  ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
   ha-color-border-neutral-normal: var(--ha-color-neutral-60)
   ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
   # Border danger
-  ha-color-border-danger-quiet: var(--ha-color-red-80)
+  ha-color-border-danger-quiet: var(--ha-color-red-90)
   ha-color-border-danger-normal: var(--ha-color-red-70)
   ha-color-border-danger-loud: var(--ha-color-red-40)
 
   # Border warning
-  ha-color-border-warning-quiet: var(--ha-color-orange-80)
+  ha-color-border-warning-quiet: var(--ha-color-orange-90)
   ha-color-border-warning-normal: var(--ha-color-orange-70)
   ha-color-border-warning-loud: var(--ha-color-orange-40)
 
   # Border success
-  ha-color-border-success-quiet: var(--ha-color-green-80)
+  ha-color-border-success-quiet: var(--ha-color-green-90)
   ha-color-border-success-normal: var(--ha-color-green-70)
   ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -279,6 +283,18 @@ Catppuccin Latte:
   ha-color-on-success-quiet: var(--ha-color-green-50)
   ha-color-on-success-normal: var(--ha-color-green-40)
   ha-color-on-success-loud: var(--white-color)
+
+  # Surfaces
+  ha-color-surface-default: var(--ha-color-neutral-95)
+  ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+  # Forms
+  ha-color-form-background: var(--ha-color-neutral-95)
+  ha-color-form-background-hover: var(--ha-color-neutral-90)
+  ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+  # Scrollable fade
+  ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
   ###################
   # HA Other Colors #
@@ -582,7 +598,11 @@ Catppuccin Frappe:
   ######################
   # HA Semantic Colors #
   ######################
-  # List from the "semantic.globals.ts" file in home-assistant/frontend.
+  # This section resets HA's semantic colors to their "light mode" settings. We do
+  # this because due to the way this theme works it is much easier to swap out the
+  # underlying palette than the semantic uses of it.
+  #
+  # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
   ha-color-focus: var(--ha-color-orange-60)
 
@@ -593,27 +613,27 @@ Catppuccin Frappe:
   ha-color-text-link: var(--catppuccin-blue)
 
   # Border primary
-  ha-color-border-primary-quiet: var(--ha-color-primary-80)
+  ha-color-border-primary-quiet: var(--ha-color-primary-90)
   ha-color-border-primary-normal: var(--ha-color-primary-70)
   ha-color-border-primary-loud: var(--ha-color-primary-40)
 
   # Border neutral
-  ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+  ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
   ha-color-border-neutral-normal: var(--ha-color-neutral-60)
   ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
   # Border danger
-  ha-color-border-danger-quiet: var(--ha-color-red-80)
+  ha-color-border-danger-quiet: var(--ha-color-red-90)
   ha-color-border-danger-normal: var(--ha-color-red-70)
   ha-color-border-danger-loud: var(--ha-color-red-40)
 
   # Border warning
-  ha-color-border-warning-quiet: var(--ha-color-orange-80)
+  ha-color-border-warning-quiet: var(--ha-color-orange-90)
   ha-color-border-warning-normal: var(--ha-color-orange-70)
   ha-color-border-warning-loud: var(--ha-color-orange-40)
 
   # Border success
-  ha-color-border-success-quiet: var(--ha-color-green-80)
+  ha-color-border-success-quiet: var(--ha-color-green-90)
   ha-color-border-success-normal: var(--ha-color-green-70)
   ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -730,6 +750,18 @@ Catppuccin Frappe:
   ha-color-on-success-quiet: var(--ha-color-green-50)
   ha-color-on-success-normal: var(--ha-color-green-40)
   ha-color-on-success-loud: var(--white-color)
+
+  # Surfaces
+  ha-color-surface-default: var(--ha-color-neutral-95)
+  ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+  # Forms
+  ha-color-form-background: var(--ha-color-neutral-95)
+  ha-color-form-background-hover: var(--ha-color-neutral-90)
+  ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+  # Scrollable fade
+  ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
   ###################
   # HA Other Colors #
@@ -1033,7 +1065,11 @@ Catppuccin Macchiato:
   ######################
   # HA Semantic Colors #
   ######################
-  # List from the "semantic.globals.ts" file in home-assistant/frontend.
+  # This section resets HA's semantic colors to their "light mode" settings. We do
+  # this because due to the way this theme works it is much easier to swap out the
+  # underlying palette than the semantic uses of it.
+  #
+  # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
   ha-color-focus: var(--ha-color-orange-60)
 
@@ -1044,27 +1080,27 @@ Catppuccin Macchiato:
   ha-color-text-link: var(--catppuccin-blue)
 
   # Border primary
-  ha-color-border-primary-quiet: var(--ha-color-primary-80)
+  ha-color-border-primary-quiet: var(--ha-color-primary-90)
   ha-color-border-primary-normal: var(--ha-color-primary-70)
   ha-color-border-primary-loud: var(--ha-color-primary-40)
 
   # Border neutral
-  ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+  ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
   ha-color-border-neutral-normal: var(--ha-color-neutral-60)
   ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
   # Border danger
-  ha-color-border-danger-quiet: var(--ha-color-red-80)
+  ha-color-border-danger-quiet: var(--ha-color-red-90)
   ha-color-border-danger-normal: var(--ha-color-red-70)
   ha-color-border-danger-loud: var(--ha-color-red-40)
 
   # Border warning
-  ha-color-border-warning-quiet: var(--ha-color-orange-80)
+  ha-color-border-warning-quiet: var(--ha-color-orange-90)
   ha-color-border-warning-normal: var(--ha-color-orange-70)
   ha-color-border-warning-loud: var(--ha-color-orange-40)
 
   # Border success
-  ha-color-border-success-quiet: var(--ha-color-green-80)
+  ha-color-border-success-quiet: var(--ha-color-green-90)
   ha-color-border-success-normal: var(--ha-color-green-70)
   ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -1181,6 +1217,18 @@ Catppuccin Macchiato:
   ha-color-on-success-quiet: var(--ha-color-green-50)
   ha-color-on-success-normal: var(--ha-color-green-40)
   ha-color-on-success-loud: var(--white-color)
+
+  # Surfaces
+  ha-color-surface-default: var(--ha-color-neutral-95)
+  ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+  # Forms
+  ha-color-form-background: var(--ha-color-neutral-95)
+  ha-color-form-background-hover: var(--ha-color-neutral-90)
+  ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+  # Scrollable fade
+  ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
   ###################
   # HA Other Colors #
@@ -1484,7 +1532,11 @@ Catppuccin Mocha:
   ######################
   # HA Semantic Colors #
   ######################
-  # List from the "semantic.globals.ts" file in home-assistant/frontend.
+  # This section resets HA's semantic colors to their "light mode" settings. We do
+  # this because due to the way this theme works it is much easier to swap out the
+  # underlying palette than the semantic uses of it.
+  #
+  # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
   ha-color-focus: var(--ha-color-orange-60)
 
@@ -1495,27 +1547,27 @@ Catppuccin Mocha:
   ha-color-text-link: var(--catppuccin-blue)
 
   # Border primary
-  ha-color-border-primary-quiet: var(--ha-color-primary-80)
+  ha-color-border-primary-quiet: var(--ha-color-primary-90)
   ha-color-border-primary-normal: var(--ha-color-primary-70)
   ha-color-border-primary-loud: var(--ha-color-primary-40)
 
   # Border neutral
-  ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+  ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
   ha-color-border-neutral-normal: var(--ha-color-neutral-60)
   ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
   # Border danger
-  ha-color-border-danger-quiet: var(--ha-color-red-80)
+  ha-color-border-danger-quiet: var(--ha-color-red-90)
   ha-color-border-danger-normal: var(--ha-color-red-70)
   ha-color-border-danger-loud: var(--ha-color-red-40)
 
   # Border warning
-  ha-color-border-warning-quiet: var(--ha-color-orange-80)
+  ha-color-border-warning-quiet: var(--ha-color-orange-90)
   ha-color-border-warning-normal: var(--ha-color-orange-70)
   ha-color-border-warning-loud: var(--ha-color-orange-40)
 
   # Border success
-  ha-color-border-success-quiet: var(--ha-color-green-80)
+  ha-color-border-success-quiet: var(--ha-color-green-90)
   ha-color-border-success-normal: var(--ha-color-green-70)
   ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -1632,6 +1684,18 @@ Catppuccin Mocha:
   ha-color-on-success-quiet: var(--ha-color-green-50)
   ha-color-on-success-normal: var(--ha-color-green-40)
   ha-color-on-success-loud: var(--white-color)
+
+  # Surfaces
+  ha-color-surface-default: var(--ha-color-neutral-95)
+  ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+  # Forms
+  ha-color-form-background: var(--ha-color-neutral-95)
+  ha-color-form-background-hover: var(--ha-color-neutral-90)
+  ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+  # Scrollable fade
+  ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
   ###################
   # HA Other Colors #
@@ -1937,7 +2001,11 @@ Catppuccin Auto Latte Frappe:
       ######################
       # HA Semantic Colors #
       ######################
-      # List from the "semantic.globals.ts" file in home-assistant/frontend.
+      # This section resets HA's semantic colors to their "light mode" settings. We do
+      # this because due to the way this theme works it is much easier to swap out the
+      # underlying palette than the semantic uses of it.
+      #
+      # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
       ha-color-focus: var(--ha-color-orange-60)
 
@@ -1948,27 +2016,27 @@ Catppuccin Auto Latte Frappe:
       ha-color-text-link: var(--catppuccin-blue)
 
       # Border primary
-      ha-color-border-primary-quiet: var(--ha-color-primary-80)
+      ha-color-border-primary-quiet: var(--ha-color-primary-90)
       ha-color-border-primary-normal: var(--ha-color-primary-70)
       ha-color-border-primary-loud: var(--ha-color-primary-40)
 
       # Border neutral
-      ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+      ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
       ha-color-border-neutral-normal: var(--ha-color-neutral-60)
       ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
       # Border danger
-      ha-color-border-danger-quiet: var(--ha-color-red-80)
+      ha-color-border-danger-quiet: var(--ha-color-red-90)
       ha-color-border-danger-normal: var(--ha-color-red-70)
       ha-color-border-danger-loud: var(--ha-color-red-40)
 
       # Border warning
-      ha-color-border-warning-quiet: var(--ha-color-orange-80)
+      ha-color-border-warning-quiet: var(--ha-color-orange-90)
       ha-color-border-warning-normal: var(--ha-color-orange-70)
       ha-color-border-warning-loud: var(--ha-color-orange-40)
 
       # Border success
-      ha-color-border-success-quiet: var(--ha-color-green-80)
+      ha-color-border-success-quiet: var(--ha-color-green-90)
       ha-color-border-success-normal: var(--ha-color-green-70)
       ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -2085,6 +2153,18 @@ Catppuccin Auto Latte Frappe:
       ha-color-on-success-quiet: var(--ha-color-green-50)
       ha-color-on-success-normal: var(--ha-color-green-40)
       ha-color-on-success-loud: var(--white-color)
+
+      # Surfaces
+      ha-color-surface-default: var(--ha-color-neutral-95)
+      ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+      # Forms
+      ha-color-form-background: var(--ha-color-neutral-95)
+      ha-color-form-background-hover: var(--ha-color-neutral-90)
+      ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+      # Scrollable fade
+      ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
       ###################
       # HA Other Colors #
@@ -2384,7 +2464,11 @@ Catppuccin Auto Latte Frappe:
       ######################
       # HA Semantic Colors #
       ######################
-      # List from the "semantic.globals.ts" file in home-assistant/frontend.
+      # This section resets HA's semantic colors to their "light mode" settings. We do
+      # this because due to the way this theme works it is much easier to swap out the
+      # underlying palette than the semantic uses of it.
+      #
+      # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
       ha-color-focus: var(--ha-color-orange-60)
 
@@ -2395,27 +2479,27 @@ Catppuccin Auto Latte Frappe:
       ha-color-text-link: var(--catppuccin-blue)
 
       # Border primary
-      ha-color-border-primary-quiet: var(--ha-color-primary-80)
+      ha-color-border-primary-quiet: var(--ha-color-primary-90)
       ha-color-border-primary-normal: var(--ha-color-primary-70)
       ha-color-border-primary-loud: var(--ha-color-primary-40)
 
       # Border neutral
-      ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+      ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
       ha-color-border-neutral-normal: var(--ha-color-neutral-60)
       ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
       # Border danger
-      ha-color-border-danger-quiet: var(--ha-color-red-80)
+      ha-color-border-danger-quiet: var(--ha-color-red-90)
       ha-color-border-danger-normal: var(--ha-color-red-70)
       ha-color-border-danger-loud: var(--ha-color-red-40)
 
       # Border warning
-      ha-color-border-warning-quiet: var(--ha-color-orange-80)
+      ha-color-border-warning-quiet: var(--ha-color-orange-90)
       ha-color-border-warning-normal: var(--ha-color-orange-70)
       ha-color-border-warning-loud: var(--ha-color-orange-40)
 
       # Border success
-      ha-color-border-success-quiet: var(--ha-color-green-80)
+      ha-color-border-success-quiet: var(--ha-color-green-90)
       ha-color-border-success-normal: var(--ha-color-green-70)
       ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -2532,6 +2616,18 @@ Catppuccin Auto Latte Frappe:
       ha-color-on-success-quiet: var(--ha-color-green-50)
       ha-color-on-success-normal: var(--ha-color-green-40)
       ha-color-on-success-loud: var(--white-color)
+
+      # Surfaces
+      ha-color-surface-default: var(--ha-color-neutral-95)
+      ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+      # Forms
+      ha-color-form-background: var(--ha-color-neutral-95)
+      ha-color-form-background-hover: var(--ha-color-neutral-90)
+      ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+      # Scrollable fade
+      ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
       ###################
       # HA Other Colors #
@@ -2833,7 +2929,11 @@ Catppuccin Auto Latte Macchiato:
       ######################
       # HA Semantic Colors #
       ######################
-      # List from the "semantic.globals.ts" file in home-assistant/frontend.
+      # This section resets HA's semantic colors to their "light mode" settings. We do
+      # this because due to the way this theme works it is much easier to swap out the
+      # underlying palette than the semantic uses of it.
+      #
+      # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
       ha-color-focus: var(--ha-color-orange-60)
 
@@ -2844,27 +2944,27 @@ Catppuccin Auto Latte Macchiato:
       ha-color-text-link: var(--catppuccin-blue)
 
       # Border primary
-      ha-color-border-primary-quiet: var(--ha-color-primary-80)
+      ha-color-border-primary-quiet: var(--ha-color-primary-90)
       ha-color-border-primary-normal: var(--ha-color-primary-70)
       ha-color-border-primary-loud: var(--ha-color-primary-40)
 
       # Border neutral
-      ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+      ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
       ha-color-border-neutral-normal: var(--ha-color-neutral-60)
       ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
       # Border danger
-      ha-color-border-danger-quiet: var(--ha-color-red-80)
+      ha-color-border-danger-quiet: var(--ha-color-red-90)
       ha-color-border-danger-normal: var(--ha-color-red-70)
       ha-color-border-danger-loud: var(--ha-color-red-40)
 
       # Border warning
-      ha-color-border-warning-quiet: var(--ha-color-orange-80)
+      ha-color-border-warning-quiet: var(--ha-color-orange-90)
       ha-color-border-warning-normal: var(--ha-color-orange-70)
       ha-color-border-warning-loud: var(--ha-color-orange-40)
 
       # Border success
-      ha-color-border-success-quiet: var(--ha-color-green-80)
+      ha-color-border-success-quiet: var(--ha-color-green-90)
       ha-color-border-success-normal: var(--ha-color-green-70)
       ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -2981,6 +3081,18 @@ Catppuccin Auto Latte Macchiato:
       ha-color-on-success-quiet: var(--ha-color-green-50)
       ha-color-on-success-normal: var(--ha-color-green-40)
       ha-color-on-success-loud: var(--white-color)
+
+      # Surfaces
+      ha-color-surface-default: var(--ha-color-neutral-95)
+      ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+      # Forms
+      ha-color-form-background: var(--ha-color-neutral-95)
+      ha-color-form-background-hover: var(--ha-color-neutral-90)
+      ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+      # Scrollable fade
+      ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
       ###################
       # HA Other Colors #
@@ -3280,7 +3392,11 @@ Catppuccin Auto Latte Macchiato:
       ######################
       # HA Semantic Colors #
       ######################
-      # List from the "semantic.globals.ts" file in home-assistant/frontend.
+      # This section resets HA's semantic colors to their "light mode" settings. We do
+      # this because due to the way this theme works it is much easier to swap out the
+      # underlying palette than the semantic uses of it.
+      #
+      # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
       ha-color-focus: var(--ha-color-orange-60)
 
@@ -3291,27 +3407,27 @@ Catppuccin Auto Latte Macchiato:
       ha-color-text-link: var(--catppuccin-blue)
 
       # Border primary
-      ha-color-border-primary-quiet: var(--ha-color-primary-80)
+      ha-color-border-primary-quiet: var(--ha-color-primary-90)
       ha-color-border-primary-normal: var(--ha-color-primary-70)
       ha-color-border-primary-loud: var(--ha-color-primary-40)
 
       # Border neutral
-      ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+      ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
       ha-color-border-neutral-normal: var(--ha-color-neutral-60)
       ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
       # Border danger
-      ha-color-border-danger-quiet: var(--ha-color-red-80)
+      ha-color-border-danger-quiet: var(--ha-color-red-90)
       ha-color-border-danger-normal: var(--ha-color-red-70)
       ha-color-border-danger-loud: var(--ha-color-red-40)
 
       # Border warning
-      ha-color-border-warning-quiet: var(--ha-color-orange-80)
+      ha-color-border-warning-quiet: var(--ha-color-orange-90)
       ha-color-border-warning-normal: var(--ha-color-orange-70)
       ha-color-border-warning-loud: var(--ha-color-orange-40)
 
       # Border success
-      ha-color-border-success-quiet: var(--ha-color-green-80)
+      ha-color-border-success-quiet: var(--ha-color-green-90)
       ha-color-border-success-normal: var(--ha-color-green-70)
       ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -3428,6 +3544,18 @@ Catppuccin Auto Latte Macchiato:
       ha-color-on-success-quiet: var(--ha-color-green-50)
       ha-color-on-success-normal: var(--ha-color-green-40)
       ha-color-on-success-loud: var(--white-color)
+
+      # Surfaces
+      ha-color-surface-default: var(--ha-color-neutral-95)
+      ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+      # Forms
+      ha-color-form-background: var(--ha-color-neutral-95)
+      ha-color-form-background-hover: var(--ha-color-neutral-90)
+      ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+      # Scrollable fade
+      ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
       ###################
       # HA Other Colors #
@@ -3729,7 +3857,11 @@ Catppuccin Auto Latte Mocha:
       ######################
       # HA Semantic Colors #
       ######################
-      # List from the "semantic.globals.ts" file in home-assistant/frontend.
+      # This section resets HA's semantic colors to their "light mode" settings. We do
+      # this because due to the way this theme works it is much easier to swap out the
+      # underlying palette than the semantic uses of it.
+      #
+      # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
       ha-color-focus: var(--ha-color-orange-60)
 
@@ -3740,27 +3872,27 @@ Catppuccin Auto Latte Mocha:
       ha-color-text-link: var(--catppuccin-blue)
 
       # Border primary
-      ha-color-border-primary-quiet: var(--ha-color-primary-80)
+      ha-color-border-primary-quiet: var(--ha-color-primary-90)
       ha-color-border-primary-normal: var(--ha-color-primary-70)
       ha-color-border-primary-loud: var(--ha-color-primary-40)
 
       # Border neutral
-      ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+      ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
       ha-color-border-neutral-normal: var(--ha-color-neutral-60)
       ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
       # Border danger
-      ha-color-border-danger-quiet: var(--ha-color-red-80)
+      ha-color-border-danger-quiet: var(--ha-color-red-90)
       ha-color-border-danger-normal: var(--ha-color-red-70)
       ha-color-border-danger-loud: var(--ha-color-red-40)
 
       # Border warning
-      ha-color-border-warning-quiet: var(--ha-color-orange-80)
+      ha-color-border-warning-quiet: var(--ha-color-orange-90)
       ha-color-border-warning-normal: var(--ha-color-orange-70)
       ha-color-border-warning-loud: var(--ha-color-orange-40)
 
       # Border success
-      ha-color-border-success-quiet: var(--ha-color-green-80)
+      ha-color-border-success-quiet: var(--ha-color-green-90)
       ha-color-border-success-normal: var(--ha-color-green-70)
       ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -3877,6 +4009,18 @@ Catppuccin Auto Latte Mocha:
       ha-color-on-success-quiet: var(--ha-color-green-50)
       ha-color-on-success-normal: var(--ha-color-green-40)
       ha-color-on-success-loud: var(--white-color)
+
+      # Surfaces
+      ha-color-surface-default: var(--ha-color-neutral-95)
+      ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+      # Forms
+      ha-color-form-background: var(--ha-color-neutral-95)
+      ha-color-form-background-hover: var(--ha-color-neutral-90)
+      ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+      # Scrollable fade
+      ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
       ###################
       # HA Other Colors #
@@ -4176,7 +4320,11 @@ Catppuccin Auto Latte Mocha:
       ######################
       # HA Semantic Colors #
       ######################
-      # List from the "semantic.globals.ts" file in home-assistant/frontend.
+      # This section resets HA's semantic colors to their "light mode" settings. We do
+      # this because due to the way this theme works it is much easier to swap out the
+      # underlying palette than the semantic uses of it.
+      #
+      # Last synced from: https://github.com/home-assistant/frontend/blob/60c5888f6ba960e41c23396a389134191c567507/src/resources/theme/color/semantic.globals.ts
 
       ha-color-focus: var(--ha-color-orange-60)
 
@@ -4187,27 +4335,27 @@ Catppuccin Auto Latte Mocha:
       ha-color-text-link: var(--catppuccin-blue)
 
       # Border primary
-      ha-color-border-primary-quiet: var(--ha-color-primary-80)
+      ha-color-border-primary-quiet: var(--ha-color-primary-90)
       ha-color-border-primary-normal: var(--ha-color-primary-70)
       ha-color-border-primary-loud: var(--ha-color-primary-40)
 
       # Border neutral
-      ha-color-border-neutral-quiet: var(--ha-color-neutral-80)
+      ha-color-border-neutral-quiet: var(--ha-color-neutral-90)
       ha-color-border-neutral-normal: var(--ha-color-neutral-60)
       ha-color-border-neutral-loud: var(--ha-color-neutral-40)
 
       # Border danger
-      ha-color-border-danger-quiet: var(--ha-color-red-80)
+      ha-color-border-danger-quiet: var(--ha-color-red-90)
       ha-color-border-danger-normal: var(--ha-color-red-70)
       ha-color-border-danger-loud: var(--ha-color-red-40)
 
       # Border warning
-      ha-color-border-warning-quiet: var(--ha-color-orange-80)
+      ha-color-border-warning-quiet: var(--ha-color-orange-90)
       ha-color-border-warning-normal: var(--ha-color-orange-70)
       ha-color-border-warning-loud: var(--ha-color-orange-40)
 
       # Border success
-      ha-color-border-success-quiet: var(--ha-color-green-80)
+      ha-color-border-success-quiet: var(--ha-color-green-90)
       ha-color-border-success-normal: var(--ha-color-green-70)
       ha-color-border-success-loud: var(--ha-color-green-40)
 
@@ -4324,6 +4472,18 @@ Catppuccin Auto Latte Mocha:
       ha-color-on-success-quiet: var(--ha-color-green-50)
       ha-color-on-success-normal: var(--ha-color-green-40)
       ha-color-on-success-loud: var(--white-color)
+
+      # Surfaces
+      ha-color-surface-default: var(--ha-color-neutral-95)
+      ha-color-on-surface-default: var(--ha-color-neutral-05)
+
+      # Forms
+      ha-color-form-background: var(--ha-color-neutral-95)
+      ha-color-form-background-hover: var(--ha-color-neutral-90)
+      ha-color-form-background-disabled: var(--ha-color-neutral-80)
+
+      # Scrollable fade
+      ha-color-shadow-scrollable-fade: rgba(0, 0, 0, 0.08)
 
       ###################
       # HA Other Colors #


### PR DESCRIPTION
This PR updates the theme to account for some new semantic colors, which fixes #81. It also updates the demo HA instance to v2026.4 to verify that the color fixes work.

Here is a before and after of the change:

![before](https://github.com/user-attachments/assets/ca9f0f9f-717f-41bf-acf4-7b93601c1088)

![after](https://github.com/user-attachments/assets/535c6bc3-cdb1-43b6-bbe9-110d0cfe578b)
