### PR TITLE
fix: support custom card styling

### DIFF
--- a/home-assistant.tera
+++ b/home-assistant.tera
@@ -12,6 +12,38 @@ graph_colors: ["mauve", "green", "red", "blue", "pink", "yellow", "sky", "maroon
   {%- set accent = 'mauve' -%}
 {%- endif -%}
 
+{%- macro textDividerStyles() -%}
+.text-divider-container {
+  --divider-color: var(--catppuccin-divider-color);
+}
+.text-divider-center {
+  border-bottom-color: var(--catppuccin-divider-color) !important;
+}
+.text-divider-center span {
+  color: var(--icon-primary-color, var(--primary-color)) !important;
+  font-weight: 300 !important;
+  background: var(--ha-card-background, var(--card-background-color)) !important;
+}
+{%- endmacro textDividerStyles -%}
+
+{%- macro customCardStyles() -%}
+:host(.type-custom-bar-card) {
+  --bar-card-border-radius: 12px;
+}
+:host(.type-custom-bar-card) ha-card,
+:host(.type-custom-button-card) ha-card.button-card-main {
+  border: none !important;
+}
+{{ self::textDividerStyles() }}
+.mdc-data-table__header-cell,
+.mdc-data-table__cell.group-header,
+.group-header {
+  color: var(--primary-color) !important;
+  font-size: 15px !important;
+  font-weight: 400 !important;
+}
+{%- endmacro customCardStyles -%}
+
 {%- macro haTheme(flavor, accent) -%}
 #####################
 # Catppuccin Colors #
@@ -280,7 +312,8 @@ dark-primary-color: var(--ha-color-primary-30)
 darker-primary-color: var(--ha-color-primary-20)
 light-primary-color: var(--ha-color-primary-50)
 accent-color: var(--primary-color)
-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+divider-color: var(--catppuccin-divider-color)
 outline-color: var(--catppuccin-crust)
 outline-hover-color: var(--catppuccin-surface2)
 
@@ -429,9 +462,35 @@ graph-color-13: var(--catppuccin-{{ graph_colors | nth(n=(graph_color_offsets[ac
 graph-color-14: var(--catppuccin-{{ graph_colors | nth(n=(graph_color_offsets[accent] + 13) % 14) }})
 {% endmacro haTheme -%}
 
+{%- macro cardModTheme() -%}
+# Custom cards via card-mod
+card-mod-card-yaml: |
+  ".": |
+    {{ self::customCardStyles() | indent(prefix="    ") }}
+  "text-divider-row $": |
+    {{ self::textDividerStyles() | indent(prefix="    ") }}
+  "button-card $": |
+    ha-card.button-card-main {
+      border: none !important;
+    }
+  "bar-card $": |
+    :host {
+      --bar-card-border-radius: 12px;
+    }
+    ha-card {
+      border: none !important;
+    }
+card-mod-card-child: |
+  {{ self::customCardStyles() | indent(prefix="  ") }}
+card-mod-row: |
+  {{ self::customCardStyles() | indent(prefix="  ") }}
+{%- endmacro cardModTheme -%}
+
 {%- for _, flavor in flavors -%}
 Catppuccin {{ flavor.identifier | capitalize }}{% if not is_default %} {{ accent | capitalize }}{% endif %}:
   {{ self::haTheme(flavor=flavor, accent=accent) | indent(prefix="  ") }}
+  {{ self::cardModTheme() | indent(prefix="  ") }}
+  card-mod-theme: Catppuccin {{ flavor.identifier | capitalize }}{% if not is_default %} {{ accent | capitalize }}{% endif %}
 
   # Inform Home Assistant that this is a single-mode theme.
   modes:
@@ -443,6 +502,8 @@ Catppuccin {{ flavor.identifier | capitalize }}{% if not is_default %} {{ accent
 {%- for _, dark_flavor in flavors -%}
 {%- if dark_flavor.dark -%}
 Catppuccin Auto {{ light_flavor.identifier | capitalize }} {{ dark_flavor.identifier | capitalize }}{% if not is_default %} {{ accent | capitalize }}{% endif %}:
+  {{ self::cardModTheme() | indent(prefix="  ") }}
+  card-mod-theme: Catppuccin Auto {{ light_flavor.identifier | capitalize }} {{ dark_flavor.identifier | capitalize }}{% if not is_default %} {{ accent | capitalize }}{% endif %}
   modes:
     light:
       {{ self::haTheme(flavor=light_flavor, accent=accent) | indent(prefix="      ") }}

--- a/home-assistant.tera
+++ b/home-assistant.tera
@@ -12,38 +12,6 @@ graph_colors: ["mauve", "green", "red", "blue", "pink", "yellow", "sky", "maroon
   {%- set accent = 'mauve' -%}
 {%- endif -%}
 
-{%- macro textDividerStyles() -%}
-.text-divider-container {
-  --divider-color: var(--catppuccin-divider-color);
-}
-.text-divider-center {
-  border-bottom-color: var(--catppuccin-divider-color) !important;
-}
-.text-divider-center span {
-  color: var(--icon-primary-color, var(--primary-color)) !important;
-  font-weight: 300 !important;
-  background: var(--ha-card-background, var(--card-background-color)) !important;
-}
-{%- endmacro textDividerStyles -%}
-
-{%- macro customCardStyles() -%}
-:host(.type-custom-bar-card) {
-  --bar-card-border-radius: 12px;
-}
-:host(.type-custom-bar-card) ha-card,
-:host(.type-custom-button-card) ha-card.button-card-main {
-  border: none !important;
-}
-{{ self::textDividerStyles() }}
-.mdc-data-table__header-cell,
-.mdc-data-table__cell.group-header,
-.group-header {
-  color: var(--primary-color) !important;
-  font-size: 15px !important;
-  font-weight: 400 !important;
-}
-{%- endmacro customCardStyles -%}
-
 {%- macro haTheme(flavor, accent) -%}
 #####################
 # Catppuccin Colors #
@@ -312,8 +280,9 @@ dark-primary-color: var(--ha-color-primary-30)
 darker-primary-color: var(--ha-color-primary-20)
 light-primary-color: var(--ha-color-primary-50)
 accent-color: var(--primary-color)
-catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-divider-color: var(--catppuccin-divider-color)
+divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+text-divider-color: var(--divider-color)
+bar-card-border-radius: 12px
 outline-color: var(--catppuccin-crust)
 outline-hover-color: var(--catppuccin-surface2)
 
@@ -466,24 +435,24 @@ graph-color-14: var(--catppuccin-{{ graph_colors | nth(n=(graph_color_offsets[ac
 # Custom cards via card-mod
 card-mod-card-yaml: |
   ".": |
-    {{ self::customCardStyles() | indent(prefix="    ") }}
+    :host(.type-custom-bar-card),
+    :host(.type-custom-button-card),
+    bar-card,
+    button-card {
+      --ha-card-border-width: 0px;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
   "text-divider-row $": |
-    {{ self::textDividerStyles() | indent(prefix="    ") }}
-  "button-card $": |
-    ha-card.button-card-main {
-      border: none !important;
+    .text-divider span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
     }
-  "bar-card $": |
-    :host {
-      --bar-card-border-radius: 12px;
-    }
-    ha-card {
-      border: none !important;
-    }
-card-mod-card-child: |
-  {{ self::customCardStyles() | indent(prefix="  ") }}
-card-mod-row: |
-  {{ self::customCardStyles() | indent(prefix="  ") }}
 {%- endmacro cardModTheme -%}
 
 {%- for _, flavor in flavors -%}

--- a/themes/catppuccin.yaml
+++ b/themes/catppuccin.yaml
@@ -314,7 +314,8 @@ Catppuccin Latte:
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
   accent-color: var(--primary-color)
-  divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  divider-color: var(--catppuccin-divider-color)
   outline-color: var(--catppuccin-crust)
   outline-hover-color: var(--catppuccin-surface2)
 
@@ -461,6 +462,110 @@ Catppuccin Latte:
   graph-color-12: var(--catppuccin-rosewater)
   graph-color-13: var(--catppuccin-sapphire)
   graph-color-14: var(--catppuccin-flamingo)
+  # Custom cards via card-mod
+  card-mod-card-yaml: |
+    ".": |
+      :host(.type-custom-bar-card) {
+        --bar-card-border-radius: 12px;
+      }
+      :host(.type-custom-bar-card) ha-card,
+      :host(.type-custom-button-card) ha-card.button-card-main {
+        border: none !important;
+      }
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+      .mdc-data-table__header-cell,
+      .mdc-data-table__cell.group-header,
+      .group-header {
+        color: var(--primary-color) !important;
+        font-size: 15px !important;
+        font-weight: 400 !important;
+      }
+    "text-divider-row $": |
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+    "button-card $": |
+      ha-card.button-card-main {
+        border: none !important;
+      }
+    "bar-card $": |
+      :host {
+        --bar-card-border-radius: 12px;
+      }
+      ha-card {
+        border: none !important;
+      }
+  card-mod-card-child: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-row: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-theme: Catppuccin Latte
 
   # Inform Home Assistant that this is a single-mode theme.
   modes:
@@ -781,7 +886,8 @@ Catppuccin Frappe:
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
   accent-color: var(--primary-color)
-  divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  divider-color: var(--catppuccin-divider-color)
   outline-color: var(--catppuccin-crust)
   outline-hover-color: var(--catppuccin-surface2)
 
@@ -928,6 +1034,110 @@ Catppuccin Frappe:
   graph-color-12: var(--catppuccin-rosewater)
   graph-color-13: var(--catppuccin-sapphire)
   graph-color-14: var(--catppuccin-flamingo)
+  # Custom cards via card-mod
+  card-mod-card-yaml: |
+    ".": |
+      :host(.type-custom-bar-card) {
+        --bar-card-border-radius: 12px;
+      }
+      :host(.type-custom-bar-card) ha-card,
+      :host(.type-custom-button-card) ha-card.button-card-main {
+        border: none !important;
+      }
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+      .mdc-data-table__header-cell,
+      .mdc-data-table__cell.group-header,
+      .group-header {
+        color: var(--primary-color) !important;
+        font-size: 15px !important;
+        font-weight: 400 !important;
+      }
+    "text-divider-row $": |
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+    "button-card $": |
+      ha-card.button-card-main {
+        border: none !important;
+      }
+    "bar-card $": |
+      :host {
+        --bar-card-border-radius: 12px;
+      }
+      ha-card {
+        border: none !important;
+      }
+  card-mod-card-child: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-row: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-theme: Catppuccin Frappe
 
   # Inform Home Assistant that this is a single-mode theme.
   modes:
@@ -1248,7 +1458,8 @@ Catppuccin Macchiato:
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
   accent-color: var(--primary-color)
-  divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  divider-color: var(--catppuccin-divider-color)
   outline-color: var(--catppuccin-crust)
   outline-hover-color: var(--catppuccin-surface2)
 
@@ -1395,6 +1606,110 @@ Catppuccin Macchiato:
   graph-color-12: var(--catppuccin-rosewater)
   graph-color-13: var(--catppuccin-sapphire)
   graph-color-14: var(--catppuccin-flamingo)
+  # Custom cards via card-mod
+  card-mod-card-yaml: |
+    ".": |
+      :host(.type-custom-bar-card) {
+        --bar-card-border-radius: 12px;
+      }
+      :host(.type-custom-bar-card) ha-card,
+      :host(.type-custom-button-card) ha-card.button-card-main {
+        border: none !important;
+      }
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+      .mdc-data-table__header-cell,
+      .mdc-data-table__cell.group-header,
+      .group-header {
+        color: var(--primary-color) !important;
+        font-size: 15px !important;
+        font-weight: 400 !important;
+      }
+    "text-divider-row $": |
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+    "button-card $": |
+      ha-card.button-card-main {
+        border: none !important;
+      }
+    "bar-card $": |
+      :host {
+        --bar-card-border-radius: 12px;
+      }
+      ha-card {
+        border: none !important;
+      }
+  card-mod-card-child: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-row: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-theme: Catppuccin Macchiato
 
   # Inform Home Assistant that this is a single-mode theme.
   modes:
@@ -1715,7 +2030,8 @@ Catppuccin Mocha:
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
   accent-color: var(--primary-color)
-  divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  divider-color: var(--catppuccin-divider-color)
   outline-color: var(--catppuccin-crust)
   outline-hover-color: var(--catppuccin-surface2)
 
@@ -1862,11 +2178,219 @@ Catppuccin Mocha:
   graph-color-12: var(--catppuccin-rosewater)
   graph-color-13: var(--catppuccin-sapphire)
   graph-color-14: var(--catppuccin-flamingo)
+  # Custom cards via card-mod
+  card-mod-card-yaml: |
+    ".": |
+      :host(.type-custom-bar-card) {
+        --bar-card-border-radius: 12px;
+      }
+      :host(.type-custom-bar-card) ha-card,
+      :host(.type-custom-button-card) ha-card.button-card-main {
+        border: none !important;
+      }
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+      .mdc-data-table__header-cell,
+      .mdc-data-table__cell.group-header,
+      .group-header {
+        color: var(--primary-color) !important;
+        font-size: 15px !important;
+        font-weight: 400 !important;
+      }
+    "text-divider-row $": |
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+    "button-card $": |
+      ha-card.button-card-main {
+        border: none !important;
+      }
+    "bar-card $": |
+      :host {
+        --bar-card-border-radius: 12px;
+      }
+      ha-card {
+        border: none !important;
+      }
+  card-mod-card-child: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-row: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-theme: Catppuccin Mocha
 
   # Inform Home Assistant that this is a single-mode theme.
   modes:
     dark: {}
 Catppuccin Auto Latte Frappe:
+  # Custom cards via card-mod
+  card-mod-card-yaml: |
+    ".": |
+      :host(.type-custom-bar-card) {
+        --bar-card-border-radius: 12px;
+      }
+      :host(.type-custom-bar-card) ha-card,
+      :host(.type-custom-button-card) ha-card.button-card-main {
+        border: none !important;
+      }
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+      .mdc-data-table__header-cell,
+      .mdc-data-table__cell.group-header,
+      .group-header {
+        color: var(--primary-color) !important;
+        font-size: 15px !important;
+        font-weight: 400 !important;
+      }
+    "text-divider-row $": |
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+    "button-card $": |
+      ha-card.button-card-main {
+        border: none !important;
+      }
+    "bar-card $": |
+      :host {
+        --bar-card-border-radius: 12px;
+      }
+      ha-card {
+        border: none !important;
+      }
+  card-mod-card-child: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-row: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-theme: Catppuccin Auto Latte Frappe
   modes:
     light:
       #####################
@@ -2184,7 +2708,8 @@ Catppuccin Auto Latte Frappe:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      divider-color: var(--catppuccin-divider-color)
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -2647,7 +3172,8 @@ Catppuccin Auto Latte Frappe:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      divider-color: var(--catppuccin-divider-color)
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -2795,6 +3321,110 @@ Catppuccin Auto Latte Frappe:
       graph-color-13: var(--catppuccin-sapphire)
       graph-color-14: var(--catppuccin-flamingo)
 Catppuccin Auto Latte Macchiato:
+  # Custom cards via card-mod
+  card-mod-card-yaml: |
+    ".": |
+      :host(.type-custom-bar-card) {
+        --bar-card-border-radius: 12px;
+      }
+      :host(.type-custom-bar-card) ha-card,
+      :host(.type-custom-button-card) ha-card.button-card-main {
+        border: none !important;
+      }
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+      .mdc-data-table__header-cell,
+      .mdc-data-table__cell.group-header,
+      .group-header {
+        color: var(--primary-color) !important;
+        font-size: 15px !important;
+        font-weight: 400 !important;
+      }
+    "text-divider-row $": |
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+    "button-card $": |
+      ha-card.button-card-main {
+        border: none !important;
+      }
+    "bar-card $": |
+      :host {
+        --bar-card-border-radius: 12px;
+      }
+      ha-card {
+        border: none !important;
+      }
+  card-mod-card-child: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-row: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-theme: Catppuccin Auto Latte Macchiato
   modes:
     light:
       #####################
@@ -3112,7 +3742,8 @@ Catppuccin Auto Latte Macchiato:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      divider-color: var(--catppuccin-divider-color)
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -3575,7 +4206,8 @@ Catppuccin Auto Latte Macchiato:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      divider-color: var(--catppuccin-divider-color)
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -3723,6 +4355,110 @@ Catppuccin Auto Latte Macchiato:
       graph-color-13: var(--catppuccin-sapphire)
       graph-color-14: var(--catppuccin-flamingo)
 Catppuccin Auto Latte Mocha:
+  # Custom cards via card-mod
+  card-mod-card-yaml: |
+    ".": |
+      :host(.type-custom-bar-card) {
+        --bar-card-border-radius: 12px;
+      }
+      :host(.type-custom-bar-card) ha-card,
+      :host(.type-custom-button-card) ha-card.button-card-main {
+        border: none !important;
+      }
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+      .mdc-data-table__header-cell,
+      .mdc-data-table__cell.group-header,
+      .group-header {
+        color: var(--primary-color) !important;
+        font-size: 15px !important;
+        font-weight: 400 !important;
+      }
+    "text-divider-row $": |
+      .text-divider-container {
+        --divider-color: var(--catppuccin-divider-color);
+      }
+      .text-divider-center {
+        border-bottom-color: var(--catppuccin-divider-color) !important;
+      }
+      .text-divider-center span {
+        color: var(--icon-primary-color, var(--primary-color)) !important;
+        font-weight: 300 !important;
+        background: var(--ha-card-background, var(--card-background-color)) !important;
+      }
+    "button-card $": |
+      ha-card.button-card-main {
+        border: none !important;
+      }
+    "bar-card $": |
+      :host {
+        --bar-card-border-radius: 12px;
+      }
+      ha-card {
+        border: none !important;
+      }
+  card-mod-card-child: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-row: |
+    :host(.type-custom-bar-card) {
+      --bar-card-border-radius: 12px;
+    }
+    :host(.type-custom-bar-card) ha-card,
+    :host(.type-custom-button-card) ha-card.button-card-main {
+      border: none !important;
+    }
+    .text-divider-container {
+      --divider-color: var(--catppuccin-divider-color);
+    }
+    .text-divider-center {
+      border-bottom-color: var(--catppuccin-divider-color) !important;
+    }
+    .text-divider-center span {
+      color: var(--icon-primary-color, var(--primary-color)) !important;
+      font-weight: 300 !important;
+      background: var(--ha-card-background, var(--card-background-color)) !important;
+    }
+    .mdc-data-table__header-cell,
+    .mdc-data-table__cell.group-header,
+    .group-header {
+      color: var(--primary-color) !important;
+      font-size: 15px !important;
+      font-weight: 400 !important;
+    }
+  card-mod-theme: Catppuccin Auto Latte Mocha
   modes:
     light:
       #####################
@@ -4040,7 +4776,8 @@ Catppuccin Auto Latte Mocha:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      divider-color: var(--catppuccin-divider-color)
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -4503,7 +5240,8 @@ Catppuccin Auto Latte Mocha:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      divider-color: var(--catppuccin-divider-color)
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 

--- a/themes/catppuccin.yaml
+++ b/themes/catppuccin.yaml
@@ -314,8 +314,9 @@ Catppuccin Latte:
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
   accent-color: var(--primary-color)
-  catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-  divider-color: var(--catppuccin-divider-color)
+  divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  text-divider-color: var(--divider-color)
+  bar-card-border-radius: 12px
   outline-color: var(--catppuccin-crust)
   outline-hover-color: var(--catppuccin-surface2)
 
@@ -465,23 +466,11 @@ Catppuccin Latte:
   # Custom cards via card-mod
   card-mod-card-yaml: |
     ".": |
-      :host(.type-custom-bar-card) {
-        --bar-card-border-radius: 12px;
-      }
-      :host(.type-custom-bar-card) ha-card,
-      :host(.type-custom-button-card) ha-card.button-card-main {
-        border: none !important;
-      }
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
-        color: var(--icon-primary-color, var(--primary-color)) !important;
-        font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
+      :host(.type-custom-bar-card),
+      :host(.type-custom-button-card),
+      bar-card,
+      button-card {
+        --ha-card-border-width: 0px;
       }
       .mdc-data-table__header-cell,
       .mdc-data-table__cell.group-header,
@@ -491,80 +480,10 @@ Catppuccin Latte:
         font-weight: 400 !important;
       }
     "text-divider-row $": |
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
+      .text-divider span {
         color: var(--icon-primary-color, var(--primary-color)) !important;
         font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
       }
-    "button-card $": |
-      ha-card.button-card-main {
-        border: none !important;
-      }
-    "bar-card $": |
-      :host {
-        --bar-card-border-radius: 12px;
-      }
-      ha-card {
-        border: none !important;
-      }
-  card-mod-card-child: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
-  card-mod-row: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
   card-mod-theme: Catppuccin Latte
 
   # Inform Home Assistant that this is a single-mode theme.
@@ -886,8 +805,9 @@ Catppuccin Frappe:
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
   accent-color: var(--primary-color)
-  catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-  divider-color: var(--catppuccin-divider-color)
+  divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  text-divider-color: var(--divider-color)
+  bar-card-border-radius: 12px
   outline-color: var(--catppuccin-crust)
   outline-hover-color: var(--catppuccin-surface2)
 
@@ -1037,23 +957,11 @@ Catppuccin Frappe:
   # Custom cards via card-mod
   card-mod-card-yaml: |
     ".": |
-      :host(.type-custom-bar-card) {
-        --bar-card-border-radius: 12px;
-      }
-      :host(.type-custom-bar-card) ha-card,
-      :host(.type-custom-button-card) ha-card.button-card-main {
-        border: none !important;
-      }
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
-        color: var(--icon-primary-color, var(--primary-color)) !important;
-        font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
+      :host(.type-custom-bar-card),
+      :host(.type-custom-button-card),
+      bar-card,
+      button-card {
+        --ha-card-border-width: 0px;
       }
       .mdc-data-table__header-cell,
       .mdc-data-table__cell.group-header,
@@ -1063,80 +971,10 @@ Catppuccin Frappe:
         font-weight: 400 !important;
       }
     "text-divider-row $": |
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
+      .text-divider span {
         color: var(--icon-primary-color, var(--primary-color)) !important;
         font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
       }
-    "button-card $": |
-      ha-card.button-card-main {
-        border: none !important;
-      }
-    "bar-card $": |
-      :host {
-        --bar-card-border-radius: 12px;
-      }
-      ha-card {
-        border: none !important;
-      }
-  card-mod-card-child: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
-  card-mod-row: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
   card-mod-theme: Catppuccin Frappe
 
   # Inform Home Assistant that this is a single-mode theme.
@@ -1458,8 +1296,9 @@ Catppuccin Macchiato:
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
   accent-color: var(--primary-color)
-  catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-  divider-color: var(--catppuccin-divider-color)
+  divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  text-divider-color: var(--divider-color)
+  bar-card-border-radius: 12px
   outline-color: var(--catppuccin-crust)
   outline-hover-color: var(--catppuccin-surface2)
 
@@ -1609,23 +1448,11 @@ Catppuccin Macchiato:
   # Custom cards via card-mod
   card-mod-card-yaml: |
     ".": |
-      :host(.type-custom-bar-card) {
-        --bar-card-border-radius: 12px;
-      }
-      :host(.type-custom-bar-card) ha-card,
-      :host(.type-custom-button-card) ha-card.button-card-main {
-        border: none !important;
-      }
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
-        color: var(--icon-primary-color, var(--primary-color)) !important;
-        font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
+      :host(.type-custom-bar-card),
+      :host(.type-custom-button-card),
+      bar-card,
+      button-card {
+        --ha-card-border-width: 0px;
       }
       .mdc-data-table__header-cell,
       .mdc-data-table__cell.group-header,
@@ -1635,80 +1462,10 @@ Catppuccin Macchiato:
         font-weight: 400 !important;
       }
     "text-divider-row $": |
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
+      .text-divider span {
         color: var(--icon-primary-color, var(--primary-color)) !important;
         font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
       }
-    "button-card $": |
-      ha-card.button-card-main {
-        border: none !important;
-      }
-    "bar-card $": |
-      :host {
-        --bar-card-border-radius: 12px;
-      }
-      ha-card {
-        border: none !important;
-      }
-  card-mod-card-child: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
-  card-mod-row: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
   card-mod-theme: Catppuccin Macchiato
 
   # Inform Home Assistant that this is a single-mode theme.
@@ -2030,8 +1787,9 @@ Catppuccin Mocha:
   darker-primary-color: var(--ha-color-primary-20)
   light-primary-color: var(--ha-color-primary-50)
   accent-color: var(--primary-color)
-  catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-  divider-color: var(--catppuccin-divider-color)
+  divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+  text-divider-color: var(--divider-color)
+  bar-card-border-radius: 12px
   outline-color: var(--catppuccin-crust)
   outline-hover-color: var(--catppuccin-surface2)
 
@@ -2181,23 +1939,11 @@ Catppuccin Mocha:
   # Custom cards via card-mod
   card-mod-card-yaml: |
     ".": |
-      :host(.type-custom-bar-card) {
-        --bar-card-border-radius: 12px;
-      }
-      :host(.type-custom-bar-card) ha-card,
-      :host(.type-custom-button-card) ha-card.button-card-main {
-        border: none !important;
-      }
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
-        color: var(--icon-primary-color, var(--primary-color)) !important;
-        font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
+      :host(.type-custom-bar-card),
+      :host(.type-custom-button-card),
+      bar-card,
+      button-card {
+        --ha-card-border-width: 0px;
       }
       .mdc-data-table__header-cell,
       .mdc-data-table__cell.group-header,
@@ -2207,80 +1953,10 @@ Catppuccin Mocha:
         font-weight: 400 !important;
       }
     "text-divider-row $": |
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
+      .text-divider span {
         color: var(--icon-primary-color, var(--primary-color)) !important;
         font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
       }
-    "button-card $": |
-      ha-card.button-card-main {
-        border: none !important;
-      }
-    "bar-card $": |
-      :host {
-        --bar-card-border-radius: 12px;
-      }
-      ha-card {
-        border: none !important;
-      }
-  card-mod-card-child: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
-  card-mod-row: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
   card-mod-theme: Catppuccin Mocha
 
   # Inform Home Assistant that this is a single-mode theme.
@@ -2290,23 +1966,11 @@ Catppuccin Auto Latte Frappe:
   # Custom cards via card-mod
   card-mod-card-yaml: |
     ".": |
-      :host(.type-custom-bar-card) {
-        --bar-card-border-radius: 12px;
-      }
-      :host(.type-custom-bar-card) ha-card,
-      :host(.type-custom-button-card) ha-card.button-card-main {
-        border: none !important;
-      }
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
-        color: var(--icon-primary-color, var(--primary-color)) !important;
-        font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
+      :host(.type-custom-bar-card),
+      :host(.type-custom-button-card),
+      bar-card,
+      button-card {
+        --ha-card-border-width: 0px;
       }
       .mdc-data-table__header-cell,
       .mdc-data-table__cell.group-header,
@@ -2316,80 +1980,10 @@ Catppuccin Auto Latte Frappe:
         font-weight: 400 !important;
       }
     "text-divider-row $": |
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
+      .text-divider span {
         color: var(--icon-primary-color, var(--primary-color)) !important;
         font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
       }
-    "button-card $": |
-      ha-card.button-card-main {
-        border: none !important;
-      }
-    "bar-card $": |
-      :host {
-        --bar-card-border-radius: 12px;
-      }
-      ha-card {
-        border: none !important;
-      }
-  card-mod-card-child: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
-  card-mod-row: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
   card-mod-theme: Catppuccin Auto Latte Frappe
   modes:
     light:
@@ -2708,8 +2302,9 @@ Catppuccin Auto Latte Frappe:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-      divider-color: var(--catppuccin-divider-color)
+      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      text-divider-color: var(--divider-color)
+      bar-card-border-radius: 12px
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -3172,8 +2767,9 @@ Catppuccin Auto Latte Frappe:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-      divider-color: var(--catppuccin-divider-color)
+      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      text-divider-color: var(--divider-color)
+      bar-card-border-radius: 12px
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -3324,23 +2920,11 @@ Catppuccin Auto Latte Macchiato:
   # Custom cards via card-mod
   card-mod-card-yaml: |
     ".": |
-      :host(.type-custom-bar-card) {
-        --bar-card-border-radius: 12px;
-      }
-      :host(.type-custom-bar-card) ha-card,
-      :host(.type-custom-button-card) ha-card.button-card-main {
-        border: none !important;
-      }
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
-        color: var(--icon-primary-color, var(--primary-color)) !important;
-        font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
+      :host(.type-custom-bar-card),
+      :host(.type-custom-button-card),
+      bar-card,
+      button-card {
+        --ha-card-border-width: 0px;
       }
       .mdc-data-table__header-cell,
       .mdc-data-table__cell.group-header,
@@ -3350,80 +2934,10 @@ Catppuccin Auto Latte Macchiato:
         font-weight: 400 !important;
       }
     "text-divider-row $": |
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
+      .text-divider span {
         color: var(--icon-primary-color, var(--primary-color)) !important;
         font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
       }
-    "button-card $": |
-      ha-card.button-card-main {
-        border: none !important;
-      }
-    "bar-card $": |
-      :host {
-        --bar-card-border-radius: 12px;
-      }
-      ha-card {
-        border: none !important;
-      }
-  card-mod-card-child: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
-  card-mod-row: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
   card-mod-theme: Catppuccin Auto Latte Macchiato
   modes:
     light:
@@ -3742,8 +3256,9 @@ Catppuccin Auto Latte Macchiato:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-      divider-color: var(--catppuccin-divider-color)
+      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      text-divider-color: var(--divider-color)
+      bar-card-border-radius: 12px
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -4206,8 +3721,9 @@ Catppuccin Auto Latte Macchiato:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-      divider-color: var(--catppuccin-divider-color)
+      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      text-divider-color: var(--divider-color)
+      bar-card-border-radius: 12px
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -4358,23 +3874,11 @@ Catppuccin Auto Latte Mocha:
   # Custom cards via card-mod
   card-mod-card-yaml: |
     ".": |
-      :host(.type-custom-bar-card) {
-        --bar-card-border-radius: 12px;
-      }
-      :host(.type-custom-bar-card) ha-card,
-      :host(.type-custom-button-card) ha-card.button-card-main {
-        border: none !important;
-      }
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
-        color: var(--icon-primary-color, var(--primary-color)) !important;
-        font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
+      :host(.type-custom-bar-card),
+      :host(.type-custom-button-card),
+      bar-card,
+      button-card {
+        --ha-card-border-width: 0px;
       }
       .mdc-data-table__header-cell,
       .mdc-data-table__cell.group-header,
@@ -4384,80 +3888,10 @@ Catppuccin Auto Latte Mocha:
         font-weight: 400 !important;
       }
     "text-divider-row $": |
-      .text-divider-container {
-        --divider-color: var(--catppuccin-divider-color);
-      }
-      .text-divider-center {
-        border-bottom-color: var(--catppuccin-divider-color) !important;
-      }
-      .text-divider-center span {
+      .text-divider span {
         color: var(--icon-primary-color, var(--primary-color)) !important;
         font-weight: 300 !important;
-        background: var(--ha-card-background, var(--card-background-color)) !important;
       }
-    "button-card $": |
-      ha-card.button-card-main {
-        border: none !important;
-      }
-    "bar-card $": |
-      :host {
-        --bar-card-border-radius: 12px;
-      }
-      ha-card {
-        border: none !important;
-      }
-  card-mod-card-child: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
-  card-mod-row: |
-    :host(.type-custom-bar-card) {
-      --bar-card-border-radius: 12px;
-    }
-    :host(.type-custom-bar-card) ha-card,
-    :host(.type-custom-button-card) ha-card.button-card-main {
-      border: none !important;
-    }
-    .text-divider-container {
-      --divider-color: var(--catppuccin-divider-color);
-    }
-    .text-divider-center {
-      border-bottom-color: var(--catppuccin-divider-color) !important;
-    }
-    .text-divider-center span {
-      color: var(--icon-primary-color, var(--primary-color)) !important;
-      font-weight: 300 !important;
-      background: var(--ha-card-background, var(--card-background-color)) !important;
-    }
-    .mdc-data-table__header-cell,
-    .mdc-data-table__cell.group-header,
-    .group-header {
-      color: var(--primary-color) !important;
-      font-size: 15px !important;
-      font-weight: 400 !important;
-    }
   card-mod-theme: Catppuccin Auto Latte Mocha
   modes:
     light:
@@ -4776,8 +4210,9 @@ Catppuccin Auto Latte Mocha:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-      divider-color: var(--catppuccin-divider-color)
+      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      text-divider-color: var(--divider-color)
+      bar-card-border-radius: 12px
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 
@@ -5240,8 +4675,9 @@ Catppuccin Auto Latte Mocha:
       darker-primary-color: var(--ha-color-primary-20)
       light-primary-color: var(--ha-color-primary-50)
       accent-color: var(--primary-color)
-      catppuccin-divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
-      divider-color: var(--catppuccin-divider-color)
+      divider-color: rgba(var(--catppuccin-overlay1-rgb), 0.15)
+      text-divider-color: var(--divider-color)
+      bar-card-border-radius: 12px
       outline-color: var(--catppuccin-crust)
       outline-hover-color: var(--catppuccin-surface2)
 


### PR DESCRIPTION
Adds focused styling for text-divider-row, bar-card, button-card, and table headers across standalone and Auto light/dark themes.

Uses the custom cards' native theme variables where possible, with one small card-mod rule for divider labels and scoped border removal. Validated all 105 flavor/accent combinations with Whiskers 2.9.0 and YAML parsing, plus live Home Assistant testing.

---
![Codex](https://img.shields.io/badge/GPT--5-000000)
